### PR TITLE
Remove DebuggerFramework abstraction

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -9,7 +9,7 @@ using JuliaInterpreter: JuliaInterpreter, JuliaStackFrame, @lookup, Compiled, Ju
       finish!, enter_call_expr, step_expr!
 
 # TODO: Work on better API in JuliaInterpreter and rewrite Debugger.jl to use it
-# These are undocumented functions used by Debugger.jl from JuliaInterpreter
+# These are undocumented functions from from JuliaInterpreter.jl used by Debugger.jl`
 using JuliaInterpreter: _make_stack, pc_expr,isassign, getlhs, do_assignment!, maybe_next_call!, is_call, _step_expr!, next_call!,  moduleof,
                         iswrappercall, next_line!, location
 

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -23,12 +23,16 @@ end
 
 export @enter
 
-include("DebuggerFramework.jl")
+include("LineNumbers.jl")
+using .LineNumbers: SourceFile, compute_line
+
+include("commands.jl")
+include("operations.jl")
 
 macro enter(arg)
     quote
         let stack = $(_make_stack(__module__,arg))
-            DebuggerFramework.RunDebugger(stack)
+            RunDebugger(stack)
         end
     end
 end

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -29,59 +29,6 @@ end
 
 include("commands.jl")
 
-const all_commands = ("q", "s", "si", "finish", "bt", "nc", "n", "se")
-
-function DebuggerFramework.language_specific_prompt(state, frame::JuliaStackFrame)
-    if haskey(state.language_modes, :julia)
-        return state.language_modes[:julia]
-    end
-    julia_prompt = LineEdit.Prompt(DebuggerFramework.promptname(state.level, "julia");
-        # Copy colors from the prompt object
-        prompt_prefix = state.repl.prompt_color,
-        prompt_suffix = (state.repl.envcolors ? Base.input_color : state.repl.input_color),
-        complete = REPL.REPLCompletionProvider(),
-        on_enter = REPL.return_callback)
-    julia_prompt.hist = state.main_mode.hist
-    julia_prompt.hist.mode_mapping[:julia] = julia_prompt
-
-    julia_prompt.on_done = (s,buf,ok)->begin
-        if !ok
-            LineEdit.transition(s, :abort)
-            return false
-        end
-        xbuf = copy(buf)
-        command = String(take!(buf))
-        @static if VERSION >= v"1.2.0-DEV.253"
-            response = DebuggerFramework.eval_code(state, command)
-            val, iserr = response
-            REPL.print_response(state.repl, response, true, true)
-        else
-            ok, result = DebuggerFramework.eval_code(state, command)
-            REPL.print_response(state.repl, ok ? result : result[1], ok ? nothing : result[2], true, true)
-        end
-        println(state.repl.t)
-
-        if !ok
-            # Convenience hack. We'll see if this is more useful or annoying
-            for c in all_commands
-                !startswith(command, c) && continue
-                LineEdit.transition(s, state.main_mode)
-                LineEdit.state(s, state.main_mode).input_buffer = xbuf
-                break
-            end
-        end
-        LineEdit.reset_state(s)
-    end
-    julia_prompt.keymap_dict = LineEdit.keymap([REPL.mode_keymap(state.main_mode);state.standard_keymap])
-    state.language_modes[:julia] = julia_prompt
-    return julia_prompt
-end
-
-function DebuggerFramework.debug(meth::Method, args...)
-    stack = [enter_call(meth, args...)]
-    DebuggerFramework.RunDebugger(stack)
-end
-
 macro enter(arg)
     quote
         let stack = $(_make_stack(__module__,arg))

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -9,12 +9,13 @@ include("DebuggerFramework.jl")
 using .DebuggerFramework
 using .DebuggerFramework: FileLocInfo, BufferLocInfo, Suppressed
 
-using JuliaInterpreter: JuliaInterpreter, JuliaStackFrame, @lookup, Compiled, JuliaProgramCounter, JuliaFrameCode
+using JuliaInterpreter: JuliaInterpreter, JuliaStackFrame, @lookup, Compiled, JuliaProgramCounter, JuliaFrameCode,
+      finish!, enter_call_expr, step_expr!
 
 # TODO: Work on better API in JuliaInterpreter and rewrite Debugger.jl to use it
-using JuliaInterpreter: _make_stack, pc_expr,
-finish!, isassign, getlhs, do_assignment!, maybe_next_call!, enter_call_expr, is_call, step_expr!, _step_expr!,
-next_call!, iswrappercall, moduleof, next_line!, location
+# These are undocumented functions used by Debugger.jl from JuliaInterpreter
+using JuliaInterpreter: _make_stack, pc_expr,isassign, getlhs, do_assignment!, maybe_next_call!, is_call, _step_expr!, next_call!,  moduleof,
+                        iswrappercall, next_line!, location
 
 export @enter
 

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -14,10 +14,6 @@ using JuliaInterpreter: _make_stack, pc_expr,isassign, getlhs, do_assignment!, m
                         iswrappercall, next_line!, location
 
 
-include("DebuggerFramework.jl")
-
-export @enter
-
 const SEARCH_PATH = []
 function __init__()
     append!(SEARCH_PATH,[joinpath(Sys.BINDIR,"../share/julia/base/"),
@@ -25,7 +21,9 @@ function __init__()
     return nothing
 end
 
-include("commands.jl")
+export @enter
+
+include("DebuggerFramework.jl")
 
 macro enter(arg)
     quote
@@ -34,4 +32,5 @@ macro enter(arg)
         end
     end
 end
+
 end # module

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -178,8 +178,7 @@ function DebuggerFramework.print_next_state(io::IO, state, frame::JuliaStackFram
     println(io)
 end
 
-const all_commands = ("q", "s", "si", "finish", "bt", "loc", "ind",
-    "up", "down", "nc", "n", "se")
+const all_commands = ("q", "s", "si", "finish", "bt", "nc", "n", "se")
 
 function DebuggerFramework.language_specific_prompt(state, frame::JuliaStackFrame)
     if haskey(state.language_modes, :julia)

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -15,8 +15,6 @@ using JuliaInterpreter: _make_stack, pc_expr,isassign, getlhs, do_assignment!, m
 
 
 include("DebuggerFramework.jl")
-using .DebuggerFramework
-using .DebuggerFramework: FileLocInfo, BufferLocInfo, Suppressed
 
 export @enter
 

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -29,41 +29,6 @@ end
 
 include("commands.jl")
 
-
-
-
-
-
-function maybe_quote(x)
-    (isa(x, Expr) || isa(x, Symbol)) ? QuoteNode(x) : x
-end
-
-function DebuggerFramework.print_next_state(io::IO, state, frame::JuliaStackFrame)
-    print(io, "About to run: ")
-    expr = pc_expr(frame, frame.pc[])
-    isa(expr, Expr) && (expr = copy(expr))
-    if isexpr(expr, :(=))
-        expr = expr.args[2]
-    end
-    if isexpr(expr, :call) || isexpr(expr, :return)
-        expr.args = map(var->maybe_quote(@lookup(frame, var)), expr.args)
-    end
-    if isa(expr, Expr)
-        for (i, arg) in enumerate(expr.args)
-            try
-                nbytes = length(repr(arg))
-                if nbytes > max(40, div(200, length(expr.args)))
-                    expr.args[i] = Suppressed("$nbytes bytes of output")
-                end
-            catch
-                expr.args[i] = Suppressed("printing error")
-            end
-        end
-    end
-    print(io, expr)
-    println(io)
-end
-
 const all_commands = ("q", "s", "si", "finish", "bt", "nc", "n", "se")
 
 function DebuggerFramework.language_specific_prompt(state, frame::JuliaStackFrame)

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -26,8 +26,9 @@ export @enter
 include("LineNumbers.jl")
 using .LineNumbers: SourceFile, compute_line
 
-include("commands.jl")
 include("operations.jl")
+include("printing.jl")
+include("commands.jl")
 
 macro enter(arg)
     quote

--- a/src/DebuggerFramework.jl
+++ b/src/DebuggerFramework.jl
@@ -110,7 +110,9 @@ end
     The second argument should default to the global environment if such
     an environment exists for the language in question.
 """
-function debug
+function debug(meth::Method, args...)
+    stack = [enter_call(meth, args...)]
+    DebuggerFramework.RunDebugger(stack)
 end
 
 mutable struct DebuggerState

--- a/src/DebuggerFramework.jl
+++ b/src/DebuggerFramework.jl
@@ -1,12 +1,13 @@
 module DebuggerFramework
 
-include("LineNumbers.jl")
-
 using .Meta: isexpr
+using Markdown
+import ..Debugger: JuliaStackFrame, location, moduleof, @lookup, pc_expr, Compiled, next_line!
+
+include("LineNumbers.jl")
+include("commands.jl")
 
 using .LineNumbers: SourceFile, compute_line
-
-import ..Debugger: JuliaStackFrame, location, moduleof, @lookup, pc_expr
 
 struct Suppressed{T}
     item::T
@@ -310,8 +311,6 @@ function print_status(io, state, frame)
     print_next_state(outbuf, state, frame)
     print(io, String(take!(outbuf.io)))
 end
-
-abstract type AbstractDiagnostic; end
 
 function execute_command
 end

--- a/src/DebuggerFramework.jl
+++ b/src/DebuggerFramework.jl
@@ -1,9 +1,12 @@
 module DebuggerFramework
 
 include("LineNumbers.jl")
+
+using .Meta: isexpr
+
 using .LineNumbers: SourceFile, compute_line
 
-import ..Debugger: JuliaStackFrame, location
+import ..Debugger: JuliaStackFrame, location, moduleof
 
 struct Suppressed{T}
     item::T
@@ -29,7 +32,34 @@ function print_var(io::IO, name, val, undef_callback)
     end
 end
 
-function print_locals(io::IO, args...)
+
+function sparam_syms(meth::Method)
+    s = Symbol[]
+    sig = meth.sig
+    while sig isa UnionAll
+        push!(s, Symbol(sig.var.name))
+        sig = sig.body
+    end
+    return s
+end
+
+function print_locals(io::IO, frame::JuliaStackFrame)
+    for i = 1:length(frame.locals)
+        if !isa(frame.locals[i], Nothing)
+            # #self# is only interesting if it has values inside of it. We already know
+            # which function we're in otherwise.
+            val = something(frame.locals[i])
+            if frame.code.code.slotnames[i] == Symbol("#self#") && (isa(val, Type) || sizeof(val) == 0)
+                continue
+            end
+            print_var(io, frame.code.code.slotnames[i], frame.locals[i], nothing)
+        end
+    end
+    if frame.code.scope isa Method
+        for (sym, value) in zip(sparam_syms(frame.code.scope), frame.sparams)
+            print_var(io, sym, value, nothing)
+        end
+    end
 end
 
 print_locdesc(io, frame) = println(io, locdesc(frame))
@@ -259,8 +289,45 @@ end
 function language_specific_prompt
 end
 
-function eval_code(state, frame, code)
-    error("Code evaluation not implemented for this debugger")
+function eval_code(state, frame::JuliaStackFrame, command)
+    expr = Base.parse_input_line(command)
+    if isexpr(expr, :toplevel)
+        expr = expr.args[end]
+    end
+    local_vars = Any[]
+    local_vals = Any[]
+    for i = 1:length(frame.locals)
+        if !isa(frame.locals[i], Nothing)
+            push!(local_vars, frame.code.code.slotnames[i])
+            push!(local_vals, QuoteNode(something(frame.locals[i])))
+        end
+    end
+    ismeth = frame.code.scope isa Method
+    ismeth && (syms = sparam_syms(frame.code.scope))
+    for i = 1:length(frame.sparams)
+        ismeth && push!(local_vars, syms[i])
+        push!(local_vals, QuoteNode(frame.sparams[i]))
+    end
+    res = gensym()
+    eval_expr = Expr(:let,
+        Expr(:block, map(x->Expr(:(=), x...), zip(local_vars, local_vals))...),
+        Expr(:block,
+            Expr(:(=), res, expr),
+            Expr(:tuple, res, Expr(:tuple, local_vars...))
+        ))
+    eval_res, res = Core.eval(moduleof(frame), eval_expr)
+    j = 1
+    for i = 1:length(frame.locals)
+        if !isa(frame.locals[i], Nothing)
+            frame.locals[i] = Some{Any}(res[j])
+            j += 1
+        end
+    end
+    for i = 1:length(frame.sparams)
+        frame.sparams[i] = res[j]
+        j += 1
+    end
+    eval_res
 end
 
 @static if VERSION >= v"1.2.0-DEV.253"

--- a/src/DebuggerFramework.jl
+++ b/src/DebuggerFramework.jl
@@ -98,10 +98,6 @@ mutable struct DebuggerState
 end
 dummy_state(stack) = DebuggerState(stack, 1, nothing, nothing, nothing, nothing, nothing, nothing)
 
-function print_status_synthtic(io, state, frame, lines_before, total_lines)
-    return 0
-end
-
 struct FileLocInfo
     filepath::String
     line::Int
@@ -193,7 +189,8 @@ function print_status(io, state, frame)
             loc.line, loc.defline)
     else
         buf = IOBuffer()
-        active_line = print_status_synthtic(buf, state, frame, 2, 5)::Int
+        # TODO: look at the = 0
+        active_line = 0
         code = split(String(take!(buf)),'\n')
         @assert active_line <= length(code)
         for (lineno, line) in enumerate(code)

--- a/src/DebuggerFramework.jl
+++ b/src/DebuggerFramework.jl
@@ -51,11 +51,6 @@ function execute_command(state, frame, ::Val{:bt}, cmd)
     return false
 end
 
-function execute_command(state, frame, ::Val{Symbol("?")}, cmd)
-    println("Help not implemented for this debugger.")
-    return false
-end
-
 function execute_command(state, frame, _, cmd)
     println("Unknown command `$cmd`. Executing `?` to obtain help.")
     execute_command(state, frame, Val{Symbol("?")}(), "?")

--- a/src/LineNumbers.jl
+++ b/src/LineNumbers.jl
@@ -9,7 +9,7 @@ struct SourceFile
 end
 Base.length(file::SourceFile) = length(file.offsets)
 
-function SourceFile(data)
+function SourceFile(data::AbstractString)
     offsets = UInt64[0]
     buf = IOBuffer(data)
     local line
@@ -23,7 +23,7 @@ function SourceFile(data)
     SourceFile(copy(codeunits(data)), offsets)
 end
 
-function compute_line(file::SourceFile, offset)
+function compute_line(file::SourceFile, offset::Integer)
     ind = searchsortedfirst(file.offsets, offset)
     ind <= length(file.offsets) && file.offsets[ind] == offset ? ind : ind - 1
 end

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -45,7 +45,7 @@ function propagate_exception!(state, exc)
     rethrow(exc)
 end
 
-function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Union{Val{:nc},Val{:n},Val{:se}}, command)
+function execute_command(state, frame::JuliaStackFrame, ::Union{Val{:nc},Val{:n},Val{:se}}, command)
     pc = try
         command == "nc" ? next_call!(Compiled(), frame) :
         command == "n" ? next_line!(Compiled(), frame, state.stack) :
@@ -63,7 +63,7 @@ function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Unio
     return true
 end
 
-function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, cmd::Union{Val{:s},Val{:si},Val{:sg}}, command)
+function execute_command(state, frame::JuliaStackFrame, cmd::Union{Val{:s},Val{:si},Val{:sg}}, command)
     pc = frame.pc[]
     first = true
     while true
@@ -123,7 +123,7 @@ function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, cmd::U
     return true
 end
 
-function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Val{:finish}, cmd)
+function execute_command(state, frame::JuliaStackFrame, ::Val{:finish}, cmd)
     state.stack[1] = JuliaStackFrame(frame, finish!(Compiled(), frame))
     perform_return!(state)
     return true
@@ -132,7 +132,7 @@ end
 """
     Runs code_typed on the call we're about to run
 """
-function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Val{:code_typed}, cmd)
+function execute_command(state, frame::JuliaStackFrame, ::Val{:code_typed}, cmd)
     expr = pc_expr(frame, frame.pc[])
     if isa(expr, Expr)
         if is_call(expr)
@@ -155,7 +155,7 @@ function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Val{
 end
 
 
-function DebuggerFramework.execute_command(state, frame::JuliaStackFrame, ::Val{:?}, cmd)
+function execute_command(state, frame::JuliaStackFrame, ::Val{:?}, cmd)
     display(
             @md_str """
     Basic Commands:\\

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,13 +1,3 @@
-module DebuggerFramework
-
-using .Meta: isexpr
-using Markdown
-import ..Debugger: JuliaStackFrame, location, moduleof, @lookup, pc_expr, Compiled, next_line!
-
-include("LineNumbers.jl")
-include("commands.jl")
-
-using .LineNumbers: SourceFile, compute_line
 
 struct Suppressed{T}
     item::T
@@ -113,7 +103,7 @@ end
 """
 function debug(meth::Method, args...)
     stack = [enter_call(meth, args...)]
-    DebuggerFramework.RunDebugger(stack)
+    RunDebugger(stack)
 end
 
 mutable struct DebuggerState
@@ -126,7 +116,6 @@ mutable struct DebuggerState
     terminal
     overall_result
 end
-dummy_state(stack) = DebuggerState(stack, 1, nothing, nothing, nothing, nothing, nothing, nothing)
 
 struct FileLocInfo
     filepath::String
@@ -322,7 +311,7 @@ function julia_prompt(state, frame::JuliaStackFrame)
     if haskey(state.language_modes, :julia)
         return state.language_modes[:julia]
     end
-    julia_prompt = LineEdit.Prompt(DebuggerFramework.promptname(state.level, "julia");
+    julia_prompt = LineEdit.Prompt(promptname(state.level, "julia");
         # Copy colors from the prompt object
         prompt_prefix = state.repl.prompt_color,
         prompt_suffix = (state.repl.envcolors ? Base.input_color : state.repl.input_color),
@@ -339,11 +328,11 @@ function julia_prompt(state, frame::JuliaStackFrame)
         xbuf = copy(buf)
         command = String(take!(buf))
         @static if VERSION >= v"1.2.0-DEV.253"
-            response = DebuggerFramework.eval_code(state, command)
+            response = eval_code(state, command)
             val, iserr = response
             REPL.print_response(state.repl, response, true, true)
         else
-            ok, result = DebuggerFramework.eval_code(state, command)
+            ok, result = eval_code(state, command)
             REPL.print_response(state.repl, ok ? result : result[1], ok ? nothing : result[2], true, true)
         end
         println(state.repl.t)
@@ -506,5 +495,3 @@ function RunDebugger(stack, repl = Base.active_repl, terminal = Base.active_repl
 
     state.overall_result
 end
-
-end # module

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,10 +1,9 @@
-
 struct Suppressed{T}
     item::T
 end
 Base.show(io::IO, x::Suppressed) = print(io, "<suppressed ", x.item, '>')
 
-function print_var(io::IO, name, val, undef_callback)
+function print_var(io::IO, name, val)
     print("  | ")
     if val === nothing
         @assert false
@@ -22,7 +21,6 @@ function print_var(io::IO, name, val, undef_callback)
         println(io, name, "::", T, " = ", val)
     end
 end
-
 
 function sparam_syms(meth::Method)
     s = Symbol[]
@@ -43,12 +41,12 @@ function print_locals(io::IO, frame::JuliaStackFrame)
             if frame.code.code.slotnames[i] == Symbol("#self#") && (isa(val, Type) || sizeof(val) == 0)
                 continue
             end
-            print_var(io, frame.code.code.slotnames[i], frame.locals[i], nothing)
+            print_var(io, frame.code.code.slotnames[i], frame.locals[i])
         end
     end
     if frame.code.scope isa Method
         for (sym, value) in zip(sparam_syms(frame.code.scope), frame.sparams)
-            print_var(io, sym, value, nothing)
+            print_var(io, sym, value)
         end
     end
 end
@@ -133,8 +131,6 @@ struct BufferLocInfo
     column::Int
     defline::Int
 end
-
-
 
 function loc_for_fname(file, line, defline)
     if startswith(string(file),"REPL[")
@@ -332,7 +328,7 @@ function julia_prompt(state, frame::JuliaStackFrame)
             REPL.print_response(state.repl, ok ? result : result[1], ok ? nothing : result[2], true, true)
         end
         println(state.repl.t)
-        
+
         if !ok
             # Convenience hack. We'll see if this is more useful or annoying
             for c in all_commands
@@ -412,8 +408,6 @@ else
     end
 end
 
-using REPL
-using REPL.LineEdit
 promptname(level, name) = "$level|$name > "
 function RunDebugger(stack, repl = Base.active_repl, terminal = Base.active_repl.t)
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -301,10 +301,6 @@ function print_status(io, state, frame)
     print(io, String(take!(outbuf.io)))
 end
 
-function execute_command
-end
-
-
 const all_commands = ("q", "s", "si", "finish", "bt", "nc", "n", "se")
 
 function julia_prompt(state, frame::JuliaStackFrame)
@@ -336,7 +332,7 @@ function julia_prompt(state, frame::JuliaStackFrame)
             REPL.print_response(state.repl, ok ? result : result[1], ok ? nothing : result[2], true, true)
         end
         println(state.repl.t)
-
+        
         if !ok
             # Convenience hack. We'll see if this is more useful or annoying
             for c in all_commands

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,0 +1,51 @@
+
+struct Suppressed{T}
+    item::T
+end
+Base.show(io::IO, x::Suppressed) = print(io, "<suppressed ", x.item, '>')
+
+function print_var(io::IO, name::Symbol, val)
+    print("  | ")
+    if val === nothing
+        @assert false
+    else
+        val = something(val)
+        T = typeof(val)
+        try
+            val = repr(val)
+            if length(val) > 150
+                val = Suppressed("$(length(val)) bytes of output")
+            end
+        catch
+            val = Suppressed("printing error")
+        end
+        println(io, name, "::", T, " = ", val)
+    end
+end
+
+print_locdesc(io::IO, frame::JuliaStackFrame) = println(io, locdesc(frame))
+
+function print_locals(io::IO, frame::JuliaStackFrame)
+    for i = 1:length(frame.locals)
+        if !isa(frame.locals[i], Nothing)
+            # #self# is only interesting if it has values inside of it. We already know
+            # which function we're in otherwise.
+            val = something(frame.locals[i])
+            if frame.code.code.slotnames[i] == Symbol("#self#") && (isa(val, Type) || sizeof(val) == 0)
+                continue
+            end
+            print_var(io, frame.code.code.slotnames[i], frame.locals[i])
+        end
+    end
+    if frame.code.scope isa Method
+        for (sym, value) in zip(sparam_syms(frame.code.scope), frame.sparams)
+            print_var(io, sym, value)
+        end
+    end
+end
+
+function print_frame(io::IO, num::Integer, frame::JuliaStackFrame)
+    print(io, "[$num] ")
+    print_locdesc(io, frame)
+    print_locals(io, frame)
+end

--- a/test/evaling.jl
+++ b/test/evaling.jl
@@ -1,4 +1,3 @@
-using DebuggerFramework
 using JuliaInterpreter
 
 # Simple evaling of function argument
@@ -6,10 +5,10 @@ function evalfoo1(x,y)
     x+y
 end
 frame = JuliaInterpreter.enter_call_expr(:($(evalfoo1)(1,2)))
-res = DebuggerFramework.eval_code(nothing, frame, "x")
+res = eval_code(nothing, frame, "x")
 @test res == 1
 
-res = DebuggerFramework.eval_code(nothing, frame, "y")
+res = eval_code(nothing, frame, "y")
 @test res == 2
 
 # Evaling with sparams
@@ -17,8 +16,8 @@ function evalsparams(x::T) where T
     x
 end
 frame = JuliaInterpreter.enter_call_expr(:($(evalsparams)(1)))
-res = DebuggerFramework.eval_code(nothing, frame, "x")
+res = eval_code(nothing, frame, "x")
 @test res == 1
 
-res = DebuggerFramework.eval_code(nothing, frame, "T")
+res = eval_code(nothing, frame, "T")
 @test res == Int

--- a/test/evaling.jl
+++ b/test/evaling.jl
@@ -1,5 +1,3 @@
-using JuliaInterpreter
-
 # Simple evaling of function argument
 function evalfoo1(x,y)
     x+y

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -2,7 +2,7 @@
 
 using JuliaInterpreter: JuliaInterpreter, pc_expr, evaluate_call!, finish_and_return!, @lookup, enter_call_expr
 # Execute a frame using Julia's regular compiled-code dispatch for any :call expressions
-runframe(frame, pc=frame.pc[]) = Some{Any}(finish_and_return!(Compiled(), frame, pc))
+runframe(frame::JuliaStackFrame, pc=frame.pc[]) = Some{Any}(finish_and_return!(Compiled(), frame, pc))
 
 stack = @make_stack map(x->2x, 1:10)
 state = dummy_state(stack)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using Debugger: Debugger, @enter, execute_command, RunDebugger
-import JuliaInterpreter: JuliaStackFrame, @lookup, _make_stack, Compiled, pc_expr, @make_stack, finish!, isexpr
+import JuliaInterpreter: JuliaStackFrame, @lookup, Compiled, pc_expr, @make_stack, finish!
 
 using Test
+using .Meta: isexpr
+import REPL
 
 #@testset "Main tests" begin
     include("utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
-using Debugger
-import Debugger: DebuggerFramework
+using Debugger: Debugger, @enter, execute_command, RunDebugger
 import JuliaInterpreter: JuliaStackFrame, @lookup, _make_stack, Compiled, pc_expr, @make_stack, finish!, isexpr
-
-import .DebuggerFramework: dummy_state, execute_command
 
 using Test
 

--- a/test/stepping.jl
+++ b/test/stepping.jl
@@ -2,7 +2,6 @@
 using JuliaInterpreter
 using Base.Meta
 using REPL
-using Debugger.DebuggerFramework: execute_command, dummy_state
 
 struct DummyState; end
 REPL.LineEdit.transition(s::DummyState, _) = nothing

--- a/test/stepping.jl
+++ b/test/stepping.jl
@@ -1,11 +1,3 @@
-
-using JuliaInterpreter
-using Base.Meta
-using REPL
-
-struct DummyState; end
-REPL.LineEdit.transition(s::DummyState, _) = nothing
-
 @test step_through(JuliaInterpreter.enter_call_expr(:($(+)(1,2.5)))) == 3.5
 @test step_through(JuliaInterpreter.enter_call_expr(:($(sin)(1)))) == sin(1)
 @test step_through(JuliaInterpreter.enter_call_expr(:($(gcd)(10,20)))) == gcd(10, 20)

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -34,7 +34,7 @@ if Sys.isunix() && VERSION >= v"1.1.0"
         repl.specialdisplay = REPL.REPLDisplay(repl)
         stack = JuliaInterpreter.@make_stack my_gcd(10, 20)
         stack[1] = JuliaInterpreter.JuliaStackFrame(stack[1], stack[1].pc[]; fullpath=false)
-        DebuggerFramework.RunDebugger(stack, repl, emuterm)
+        RunDebugger(stack, repl, emuterm)
     end
 else
     @warn "Skipping UI tests on non unix systems"

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -1,5 +1,5 @@
-using JuliaInterpreter, REPL
-
+# 
+#
 # From base, but copied here to make sure we don't fail bacause base changed
 function my_gcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}
     a == 0 && return abs(b)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,8 @@
+dummy_state(stack) = Debugger.DebuggerState(stack, 1, nothing, nothing, nothing, nothing, nothing, nothing)
+
 # Steps through the whole expression using `s`
 function step_through(frame)
-    state = DebuggerFramework.dummy_state([frame])
+    state = dummy_state([frame])
     while !isexpr(pc_expr(state.stack[end]), :return)
         execute_command(state, state.stack[1], Val{:s}(), "s")
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-dummy_state(stack) = Debugger.DebuggerState(stack, 1, nothing, nothing, nothing, nothing, nothing, nothing)
+dummy_state(stack) = Debugger.DebuggerState(stack, nothing)
 
 # Steps through the whole expression using `s`
 function step_through(frame)


### PR DESCRIPTION
DebuggerFramework is an API created to facilitate writing REPL debugger interfaces by overloading a few functions. Debugger.jl is the only working consumer of that API (and likely will continue to be so).

Since there is only one package using the API (and in fact that package bundles it) there is not really any point keeping the abstraction since it just makes things less flexible.

This PR therefore gets rid of DebuggerFramework in favour of normal methods.