### PR TITLE
Debugger.jl: fix duplicated word in comment

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -10,7 +10,7 @@ using JuliaInterpreter: JuliaInterpreter, JuliaStackFrame, @lookup, Compiled, Ju
       finish!, enter_call_expr, step_expr!
 
 # TODO: Work on better API in JuliaInterpreter and rewrite Debugger.jl to use it
-# These are undocumented functions from from JuliaInterpreter.jl used by Debugger.jl`
+# These are undocumented functions from JuliaInterpreter.jl used by Debugger.jl`
 using JuliaInterpreter: _make_stack, pc_expr,isassign, getlhs, do_assignment!, maybe_next_call!, is_call, _step_expr!, next_call!,  moduleof,
                         iswrappercall, next_line!, linenumber
 


### PR DESCRIPTION
I inadvertently led to the introduction of this typo in [this conversation](https://github.com/JuliaDebug/Debugger.jl/pull/13#discussion_r258071442). This PR fixes that.