### PR TITLE
fix regex for quotenode removal

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -250,7 +250,7 @@ function print_codeinfo(io::IO, frame::JuliaStackFrame)
         !(line == "CodeInfo(" || line == ")" || isempty(line))
     end
 
-    code .= replace.(code, Ref(r"\$\(QuoteNode\((.*)\)\)" => s"\1"))
+    code .= replace.(code, Ref(r"\$\(QuoteNode\((.+?)\)\)" => s"\1"))
 
     for (lineno, line) in enumerate(code)
         (lineno < active_line - 3 || lineno > active_line + 2) && continue


### PR DESCRIPTION
Original:
```
3   │   %3 = ($(QuoteNode(Branch)))($(QuoteNode(LinearAlgebra.det)), %1, %2)
```
Before this PR:
```
3   │   %3 = (Branch)))($(QuoteNode(LinearAlgebra.det, %1, %2)
```
After this PR:
```
3   │   %3 = (Branch)(LinearAlgebra.det, %1, %2)
```