### PR TITLE
prevent stepping in non toplevel frames

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -45,7 +45,14 @@ function propagate_exception!(state::DebuggerState, exc)
     rethrow(exc)
 end
 
+function assert_is_toplevel_frame(state)
+    state.level == 1 && return true
+    printstyled(stderr, "Cannot step or mutate variables in a non toplevel frame,\n"; color=:red)
+    return false
+end
+
 function execute_command(state::DebuggerState, frame::JuliaStackFrame, ::Union{Val{:nc},Val{:n},Val{:se}}, cmd::AbstractString)
+    assert_is_toplevel_frame(state) || return false
     pc = try
         cmd == "nc" ? next_call!(Compiled(), frame) :
         cmd == "n" ? next_line!(Compiled(), frame, state.stack) :
@@ -64,6 +71,7 @@ function execute_command(state::DebuggerState, frame::JuliaStackFrame, ::Union{V
 end
 
 function execute_command(state::DebuggerState, frame, cmd::Union{Val{:s},Val{:si},Val{:sg}}, command::AbstractString)
+    assert_is_toplevel_frame(state) || return false
     pc = frame.pc[]
     first = true
     while true
@@ -124,6 +132,7 @@ function execute_command(state::DebuggerState, frame, cmd::Union{Val{:s},Val{:si
 end
 
 function execute_command(state::DebuggerState, frame::JuliaStackFrame, ::Val{:finish}, cmd::AbstractString)
+    assert_is_toplevel_frame(state) || return false
     state.stack[end] = JuliaStackFrame(frame, finish!(Compiled(), frame))
     perform_return!(state)
     return true

--- a/test/stepping.jl
+++ b/test/stepping.jl
@@ -200,3 +200,17 @@ end
 
 B_inst = B{Int}()
 step_through(JuliaInterpreter.enter_call_expr(:($(B_inst)(10))))
+
+# Stepping in non toplevel frames
+@info " BEGIN ERRORS -------------------------------------"
+f2(x) = f1(x)
+f1(x) = x
+stack = @make_stack f2(1)
+state = dummy_state(stack)
+execute_command(state, state.stack[end], Val{:s}(), "s")
+execute_command(state, state.stack[end], Val{:fr}(), "fr 2")
+@test execute_command(state, state.stack[end], Val{:s}(), "s") == false
+@test execute_command(state, state.stack[end], Val{:n}(), "n") == false
+@test execute_command(state, state.stack[end], Val{:finish}(), "finish") == false
+@info " END ERRORS ---------------------------------------"
+


### PR DESCRIPTION
Fixes #34 

Might also want to make sure we are not modifying locals in `eval_code` but that is much harder. It would also not make the interpreter itself crash, just give weird execution.