### PR TITLE
get rid of explicit frame command to execute_command

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -40,6 +40,8 @@ end
 DebuggerState(stack, repl, terminal) = DebuggerState(stack, 1, repl, terminal, nothing, Ref{LineEdit.Prompt}(), nothing, nothing)
 DebuggerState(stack, repl) = DebuggerState(stack, repl, nothing)
 
+active_frame(state) = state.stack[end - state.level + 1]
+
 include("locationinfo.jl")
 include("repl.jl")
 include("commands.jl")

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -37,7 +37,7 @@ function print_frame(io::IO, num::Integer, frame::JuliaStackFrame)
 end
 
 
-function print_next_state(io::IO, state::DebuggerState, frame::JuliaStackFrame)
+function print_next_expr(io::IO, frame::JuliaStackFrame)
     maybe_quote(x) = (isa(x, Expr) || isa(x, Symbol)) ? QuoteNode(x) : x
 
     print(io, "About to run: ")
@@ -65,8 +65,7 @@ function print_next_state(io::IO, state::DebuggerState, frame::JuliaStackFrame)
     println(io)
 end
 
-print_status(io::IO, state::DebuggerState) = print_status(io, state, state.stack[end - state.level + 1])
-function print_status(io::IO, state::DebuggerState, frame::JuliaStackFrame)
+function print_status(io::IO, frame::JuliaStackFrame)
     # Buffer to avoid flickering
     outbuf = IOContext(IOBuffer(), io)
     printstyled(outbuf, "In ", locdesc(frame), "\n"; color=:bold)
@@ -83,7 +82,7 @@ function print_status(io::IO, state::DebuggerState, frame::JuliaStackFrame)
     else
         print_codeinfo(outbuf, frame)
     end
-    print_next_state(outbuf, state, frame)
+    print_next_expr(outbuf, frame)
     print(io, String(take!(outbuf.io)))
 end
 

--- a/test/evaling.jl
+++ b/test/evaling.jl
@@ -5,12 +5,11 @@ function evalfoo1(x,y)
     x+y
 end
 frame = JuliaInterpreter.enter_call_expr(:($(evalfoo1)(1,2)))
-state = dummy_state([frame])
-res = eval_code(state, frame, "x")
+res = eval_code(frame, "x")
 
 @test res == 1
 
-res = eval_code(state, frame, "y")
+res = eval_code(frame, "y")
 @test res == 2
 
 # Evaling with sparams
@@ -18,21 +17,19 @@ function evalsparams(x::T) where T
     x
 end
 frame = JuliaInterpreter.enter_call_expr(:($(evalsparams)(1)))
-state = dummy_state([frame])
-res = eval_code(state, frame, "x")
+res = eval_code(frame, "x")
 @test res == 1
-eval_code(state, frame, "x = 3")
-res = eval_code(state, frame, "x")
+eval_code(frame, "x = 3")
+res = eval_code(frame, "x")
 @test res == 3
-res = eval_code(state, frame, "T")
+res = eval_code(frame, "T")
 @test res == Int
-eval_code(state, frame, "T = Float32")
-res = eval_code(state, frame, "T")
+eval_code(frame, "T = Float32")
+res = eval_code(frame, "T")
 @test res == Float32
 
 # Evaling with keywords
 evalkw(x; bar=true) = x
 stack = @make_stack evalkw(2)
-state = dummy_state(stack)
-res = eval_code(state, stack[end], "x")
+res = eval_code(stack[end], "x")
 @test res == 2

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,7 +6,7 @@ runframe(frame::JuliaStackFrame, pc=frame.pc[]) = Some{Any}(finish_and_return!(C
 
 stack = @make_stack map(x->2x, 1:10)
 state = dummy_state(stack)
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 @test isempty(state.stack)
 @test state.overall_result == 2 .* [1:10...]
 
@@ -17,8 +17,8 @@ function complicated_keyword_stuff(args...; kw...)
 end
 stack = @make_stack complicated_keyword_stuff(1)
 state = dummy_state(stack)
-execute_command(state, state.stack[end], Val{:n}(), "n")
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:n}(), "n")
+execute_command(state, Val{:finish}(), "finish")
 @test isempty(state.stack)
 
 @test runframe(JuliaInterpreter.enter_call(complicated_keyword_stuff, 1, 2)) ==

--- a/test/stepping.jl
+++ b/test/stepping.jl
@@ -11,13 +11,13 @@ frame = JuliaInterpreter.enter_call_expr(:($(callgenerated)()))
 state = dummy_state([frame])
 
 # Step into the generated function itself
-execute_command(state, state.stack[end], Val{:sg}(), "sg")
+execute_command(state, Val{:sg}(), "sg")
 
 # Should now be in generated function
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 
 # Now finish the regular function
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 
 @test isempty(state.stack)
 
@@ -31,11 +31,11 @@ end
 frame = JuliaInterpreter.enter_call_expr(:($(optional)()))
 state = dummy_state([frame])
 # First call steps in
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # cos(1.0)
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # return
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 
 @test isempty(state.stack)
 
@@ -62,16 +62,16 @@ end
 frame = JuliaInterpreter.enter_call_expr(:($(test_macro)()))
 state = dummy_state([frame])
 # a = sin(5)
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # b = asin(5)
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # @insert_some_calls
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # TODO: Is this right?
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 # return z
-execute_command(state, state.stack[end], Val{:n}(), "n")
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 @test isempty(state.stack)
 
 # Test stepping into functions with keyword arguments
@@ -80,14 +80,14 @@ g() = f(1; b = 2)
 frame = JuliaInterpreter.enter_call_expr(:($(g)()));
 state = dummy_state([frame])
 # Step to the actual call
-execute_command(state, state.stack[end], Val{:nc}(), "nc")
-execute_command(state, state.stack[end], Val{:nc}(), "nc")
-execute_command(state, state.stack[end], Val{:nc}(), "nc")
+execute_command(state, Val{:nc}(), "nc")
+execute_command(state, Val{:nc}(), "nc")
+execute_command(state, Val{:nc}(), "nc")
 # Step in
-execute_command(state, state.stack[end], Val{:s}(), "s")
+execute_command(state, Val{:s}(), "s")
 # Should get out in two steps
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 @test isempty(state.stack)
 
 # Test stepping into functions with exception frames
@@ -108,14 +108,14 @@ end
 stack = @make_stack f_exc()
 state = dummy_state(stack)
 
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 @test isempty(state.stack)
 
 stack = @make_stack g_exc()
 state = dummy_state(stack)
 
-execute_command(state, state.stack[end], Val{:n}(), "n")
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 @test isempty(state.stack)
 @test state.overall_result isa ErrorException
 
@@ -135,9 +135,9 @@ end
 stack = @make_stack f_exc_outer()
 state = dummy_state(stack)
 
-execute_command(state, state.stack[end], Val{:s}(), "s")
-execute_command(state, state.stack[end], Val{:n}(), "n")
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:s}(), "s")
+execute_command(state, Val{:n}(), "n")
+execute_command(state, Val{:n}(), "n")
 @test isempty(state.stack)
 @test state.overall_result isa ErrorException
 
@@ -147,9 +147,9 @@ f_symbol() = :limit => true
 stack = @make_stack f_symbol()
 state = dummy_state(stack)
 
-execute_command(state, state.stack[end], Val{:s}(), "s")
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:s}(), "s")
+execute_command(state, Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 @test isempty(state.stack)
 @test state.overall_result == f_symbol()
 
@@ -160,11 +160,11 @@ f_va_outer(args...) = f_va_inner(args...)
 stack = @make_stack f_va_outer(1)
 state = dummy_state(stack)
 
-execute_command(state, state.stack[end], Val{:s}(), "s")
-execute_command(state, state.stack[end], Val{:n}(), "n")
+execute_command(state, Val{:s}(), "s")
+execute_command(state, Val{:n}(), "n")
 @test !isempty(state.stack)
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
-execute_command(state, state.stack[end], Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
+execute_command(state, Val{:finish}(), "finish")
 @test isempty(state.stack)
 @test state.overall_result == 2
 
@@ -173,8 +173,8 @@ f(foo; bar=3) = foo+bar
 stack = @make_stack f(2, bar=4)
 @test length(stack) > 1
 state = dummy_state(stack)
-execute_command(state, state.stack[end], Val{:n}(), "nc")
-execute_command(state, state.stack[end], Val{:n}(), "nc")
+execute_command(state, Val{:n}(), "nc")
+execute_command(state, Val{:n}(), "nc")
 @test isempty(state.stack)
 @test state.overall_result == 6
 
@@ -186,7 +186,7 @@ end
 stack = @make_stack foo_error(3,1)
 state = dummy_state(stack)
 try
-    execute_command(state, state.stack[end], Val{:n}(), "n")
+    execute_command(state, Val{:n}(), "n")
 catch e
     @test isa(e, ErrorException)
 end
@@ -207,10 +207,10 @@ f2(x) = f1(x)
 f1(x) = x
 stack = @make_stack f2(1)
 state = dummy_state(stack)
-execute_command(state, state.stack[end], Val{:s}(), "s")
-execute_command(state, state.stack[end], Val{:fr}(), "fr 2")
-@test execute_command(state, state.stack[end], Val{:s}(), "s") == false
-@test execute_command(state, state.stack[end], Val{:n}(), "n") == false
-@test execute_command(state, state.stack[end], Val{:finish}(), "finish") == false
+execute_command(state, Val{:s}(), "s")
+execute_command(state, Val{:fr}(), "fr 2")
+@test execute_command(state, Val{:s}(), "s") == false
+@test execute_command(state, Val{:n}(), "n") == false
+@test execute_command(state, Val{:finish}(), "finish") == false
 @info " END ERRORS ---------------------------------------"
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,7 +4,7 @@ dummy_state(stack) = Debugger.DebuggerState(stack, nothing)
 function step_through(frame)
     state = dummy_state([frame])
     while !isexpr(pc_expr(state.stack[1]), :return)
-        execute_command(state, state.stack[end], Val{:s}(), "s")
+        execute_command(state, Val{:s}(), "s")
     end
     lastframe = state.stack[1]
     return @lookup(lastframe, pc_expr(lastframe).args[1])


### PR DESCRIPTION
Should make the code structurally a bit more similar to how things will be with the linked list stuff.