### PR TITLE
Avoid attempt to print `nothing` when stepping

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -8,8 +8,8 @@ using REPL.REPLCompletions
 
 using JuliaInterpreter: JuliaInterpreter, Frame, @lookup, FrameCode, BreakpointRef, debug_command, leaf, root
 
-using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args, 
-                        root, caller, whereis, get_return
+using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args,
+                        root, caller, whereis, get_return, nstatements
 
 const SEARCH_PATH = []
 function __init__()

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -40,8 +40,14 @@ end
 function print_next_expr(io::IO, frame::Frame)
     maybe_quote(x) = (isa(x, Expr) || isa(x, Symbol)) ? QuoteNode(x) : x
 
+    pc = frame.pc
+    expr = pc_expr(frame, pc)
+    while expr === nothing
+        pc += 1
+        pc <= nstatements(frame.framecode) || return nothing
+        expr = pc_expr(frame, pc)
+    end
     print(io, "About to run: ")
-    expr = pc_expr(frame, frame.pc[])
     isa(expr, Expr) && (expr = copy(expr))
     if isexpr(expr, :(=))
         expr = expr.args[2]

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -42,3 +42,9 @@ execute_command(state, Val{:so}(), "c")
 execute_command(state, Val{:so}(), "c")
 @test state.frame === nothing
 @test state.overall_result == 2
+
+@inline fnothing(x) = 1
+frame = JuliaInterpreter.enter_call(fnothing, 0)
+io = IOBuffer()
+Debugger.print_next_expr(io, frame)
+@test chomp(String(take!(io))) == "About to run: return 1"


### PR DESCRIPTION
This showed up while mixing `nc` and `s` with default- and keyword-argument methods.