### PR TITLE
always go to the leaf frame after executing a command

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -41,6 +41,7 @@ function execute_command(state::DebuggerState, ::Union{Val{:c},Val{:nc},Val{:n},
         return false
     else
         state.frame, pc = ret
+        state.frame = leaf(state.frame)
         if pc isa BreakpointRef
             if pc.stmtidx != 0 # This is the dummy breakpoint to stop just after entering a call
                 if state.terminal !== nothing # fix this, it happens when a test hits this and hasnt set a terminal


### PR DESCRIPTION
https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/b76bc3d3d36a0359ab08db511896fe17645af9fb/src/commands.jl#L164-L165

suggests to me that there are cases where e.g. `next_line!` steps into a new frame. Therefore we need to go to that leaf frame. Always doing it seems like it shouldn't hurt.