### PR TITLE
use system colors as default on all OSs

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -151,7 +151,7 @@ end
     HIGHLIGHT_24_BIT
 end
 
-const _syntax_highlighting = Ref(Sys.iswindows() ? HIGHLIGHT_SYSTEM_COLORS : HIGHLIGHT_256_COLORS)
+const _syntax_highlighting = Ref(HIGHLIGHT_SYSTEM_COLORS)
 const _current_theme = Ref{Type{<:Highlights.AbstractTheme}}(Highlights.Themes.MonokaiTheme)
 
 set_theme(theme::Type{<:Highlights.AbstractTheme}) = _current_theme[] = theme


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/54519362-a4affe80-4966-11e9-912b-ccb0a1607324.png)
is a bit too low contrast for my taste :)

Using system colors is imho the only sane default (although people tend to do crazy things with those too).