### PR TITLE
don't run recursive interpretation unless there is a chance of breaking

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -10,7 +10,7 @@ using REPL.LineEdit
 using REPL.REPLCompletions
 
 using CodeTracking
-using JuliaInterpreter: JuliaInterpreter, Frame, @lookup, FrameCode, BreakpointRef, debug_command, leaf, root
+using JuliaInterpreter: JuliaInterpreter, Frame, @lookup, FrameCode, BreakpointRef, debug_command, leaf, root, Compiled, finish_and_return!
 
 using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args,
                         root, caller, whereis, get_return, nstatements

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ if !isdefined(Main, :isnothing)
 end
 
 Debugger.set_highlight(Debugger.HIGHLIGHT_OFF)
+Debugger.always_run_recursive_interpret[] = true
 
 #@testset "Main tests" begin
     include("utils.jl")


### PR DESCRIPTION
If someone is just stepping, we might as well use compiled mode like back in the days.

Does this makes sense to you @timholy?