### PR TITLE
improve breakpoint printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ julia> using Debugger, JuliaInterpreter
 julia> breakpoint(abs);
 
 julia> @run sin(2.0)
-Hit breakpoint: abs(x::Float64) in Base at float.jl:522, line 522
-In abs(x) at float.jl:522
-522   abs(x::Float64) = abs_float(x)
-523
-524   """
+Hit breakpoint:
+In abs(x) at float.jl
+>522  abs(x::Float64) = abs_float(x)
+ 523  
+ 524  """
+ 525      isnan(f) -> Bool
+ 526
 
 About to run: (abs_float)(2.0)
 1|debug> bt
@@ -94,12 +96,15 @@ julia> break_on(:error)
 
 julia> f() = "αβ"[2];
 
-> @run f()
-Breaking on error: string_index_err(s::AbstractString, i::Integer) in Base at strings/string.jl:12, line 12, StringIndexError("αβ", 2)
-In string_index_err(s, i) at strings/string.jl:12
-12  @noinline string_index_err(s::AbstractString, i::Integer) =
-13      throw(StringIndexError(s, Int(i)))
-14
+julia> @run f()
+Breaking for error:
+ERROR: StringIndexError("αβ", 2)
+In string_index_err(s, i) at strings/string.jl
+>12  @noinline string_index_err(s::AbstractString, i::Integer) =
+ 13      throw(StringIndexError(s, Int(i)))
+ 14  
+ 15  const ByteArray = Union{Vector{UInt8},Vector{Int8}}
+ 16  
 
 About to run: (throw)(StringIndexError("αβ", 2))
 1|debug> bt

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -14,27 +14,12 @@ end
 function show_breakpoint(io::IO, bp::BreakpointRef)
     outbuf = IOContext(IOBuffer(), io)
     if bp.err === nothing
-        print(outbuf, "Hit breakpoint: ")
+        print(outbuf, "Hit breakpoint:\n")
     else
-        print(outbuf, "Breaking on error: ")
-    end
-    code = bp.framecode
-    if code.scope isa Method
-        scope_str = sprint(locdesc, code)
-    else
-        scope_str = repr(code.scope)
-    end
-    if checkbounds(Bool, bp.framecode.breakpoints, bp.stmtidx)
-        lineno = linenumber(bp.framecode, bp.stmtidx)
-        print(outbuf, scope_str, ", line ", lineno)
-    else
-        print(outbuf, scope_str, ", %", bp.stmtidx)
-    end
-    if bp.err !== nothing
-        print(outbuf, ", ", bp.err)
+        print(outbuf, "Breaking for error:\n")
+        Base.display_error(outbuf, bp.err, [])
     end
     print(io, String(take!(outbuf.io)))
-    println(io)
 end
 
 function execute_command(state::DebuggerState, ::Union{Val{:c},Val{:nc},Val{:n},Val{:se},Val{:s},Val{:si},Val{:sg},Val{:so}}, cmd::AbstractString)

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -53,8 +53,8 @@ end
         using TerminalRegressionTests
 
         function run_terminal_test(frame, commands, validation)
-            #TerminalRegressionTests.automated_test(joinpath(@__DIR__, validation), commands) do emuterm
-            TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm                
+            TerminalRegressionTests.automated_test(joinpath(@__DIR__, validation), commands) do emuterm
+            #TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm                
                 repl = REPL.LineEditREPL(emuterm, true)
                 repl.interface = REPL.setup_interface(repl)
                 repl.specialdisplay = REPL.REPLDisplay(repl)

--- a/test/ui/history_gcd.multiout
+++ b/test/ui/history_gcd.multiout
@@ -2105,7 +2105,7 @@
 |
 |About to run: (===)(20, 0)
 |1|debug> c
-|Hit breakpoint: my_gcd(a, b) at ui.jl:5, line 12
+|Hit breakpoint:
 |In my_gcd(a, b) at ui.jl:5
 |  8  zb = trailing_zeros(b)
 |  9  k = min(za, zb)
@@ -2217,7 +2217,7 @@
 |
 |AAAAAAAAAAAAAAAAAAAAAAAAAA
 |EEEEEEEEEA
-|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAA
@@ -2329,7 +2329,7 @@
 |
 |About to run: (===)(20, 0)
 |1|debug> c
-|Hit breakpoint: my_gcd(a, b) at ui.jl:5, line 12
+|Hit breakpoint:
 |In my_gcd(a, b) at ui.jl:5
 |  8  zb = trailing_zeros(b)
 |  9  k = min(za, zb)
@@ -2441,7 +2441,7 @@
 |
 |AAAAAAAAAAAAAAAAAAAAAAAAAA
 |EEEEEEEEEA
-|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAAAAAAAAA
 |AAAAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
```
julia> @run f()
Breaking for error:
ERROR: StringIndexError("αβ", 2)
In string_index_err(s, i) at strings/string.jl
>12  @noinline string_index_err(s::AbstractString, i::Integer) =
 13      throw(StringIndexError(s, Int(i)))
 14
 15  const ByteArray = Union{Vector{UInt8},Vector{Int8}}
 16

About to run: (throw)(StringIndexError("αβ", 2))
1|debug>
```

Fixes https://github.com/JuliaDebug/Debugger.jl/issues/95