### PR TITLE
fix showing keyword calls

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,10 +4,12 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
-deps = ["InteractiveUtils", "Test", "UUIDs"]
-git-tree-sha1 = "2c46bc2429c88b43d80caf53151f22b85ba5a4b2"
+deps = ["InteractiveUtils", "UUIDs"]
+git-tree-sha1 = "9e697f312e39a94fc9e0368672662d34b0054a43"
+repo-rev = "master"
+repo-url = "https://github.com/timholy/CodeTracking.jl.git"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.3.4"
+version = "0.4.0"
 
 [[Crayons]]
 deps = ["Test"]
@@ -41,7 +43,7 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "1d4df77f80cb7ff450ac0c59e0b906a3713537b2"
+git-tree-sha1 = "1ccddcf4eac5f32aa0d559fa73dbf9b965d239fb"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-CodeTracking = "0.3.2"
+CodeTracking = "0.3.2, 0.4"
 Crayons = "3"
 Highlights = "0.3.1"
 JuliaInterpreter = "0.2"

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -83,6 +83,7 @@ function _make_frame(mod, arg)
     quote
         theargs = $(esc(args))
         frame = JuliaInterpreter.enter_call_expr(Expr(:call,theargs...))
+        frame = JuliaInterpreter.maybe_step_through_kwprep!(frame)
         frame = JuliaInterpreter.maybe_step_through_wrapper!(frame)
         JuliaInterpreter.maybe_next_call!(frame)
         frame

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -37,7 +37,12 @@ function print_frame(io::IO, num::Integer, frame::Frame)
 end
 
 function pattern_match_kw_call(expr)
-    is_kw = isexpr(expr, :call) && occursin("#kw#", string(expr.args[1]))
+    if isexpr(expr, :call)
+        f = string(expr.args[1])
+        is_kw = occursin("#kw#", f) || (startswith(f, "#") && endswith(f, "_kw"))
+    else
+        is_kw = false
+    end
     is_kw || return expr
     args = length(expr.args) >= 4 ? expr.args[4:end] : []
     kws_nt = expr.args[2]

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -47,6 +47,17 @@ function my_gcd_noinfo(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,
 end
 """, "nope.jl")
 
+
+function outer(a, b, c, d)
+    inner_kw(a, b; c = c)
+end
+
+function inner_kw(a, b; c = 3, d = 10)
+    return a + b + c + d
+end
+
+
+
 @testset "UI" begin
     if Sys.isunix() && VERSION >= v"1.1.0"
         Debugger._print_full_path[] = false
@@ -72,6 +83,10 @@ end
                            "s\n", "fr 1\n", "fr 2\n", "f 2\n", "f 1\n",
                            "bt\n", "st\n", "C", "c\n", "C", "c\n"],
                           "ui/history_gcd.multiout")
+
+        run_terminal_test(@make_frame(outer(1, 2, 5, 20)),
+                          ["s\n", "c\n"],
+                          "ui/history_kw.multiout")
         
         if v"1.1">= VERSION < v"1.2"
             run_terminal_test(@make_frame(my_gcd_noinfo(10, 20)),

--- a/test/ui/history_kw.multiout
+++ b/test/ui/history_kw.multiout
@@ -1,0 +1,58 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|In outer(a, b, c, d) at ui.jl:52
+|>52      inner_kw(a, b; c = c)
+| 53  end
+| 54  
+| 55  function inner_kw(a, b; c = 3, d = 10)
+| 56      return a + b + c + d
+|
+|About to run: (inner_kw)(1, 2; c=5)
+|1|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAA
+|AAAAA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCC
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|In outer(a, b, c, d) at ui.jl:52
+|>52      inner_kw(a, b; c = c)
+| 53  end
+| 54  
+| 55  function inner_kw(a, b; c = 3, d = 10)
+| 56      return a + b + c + d
+|
+|About to run: (inner_kw)(1, 2; c=5)
+|1|debug> s
+|In #inner_kw#13(c, d, , a, b) at ui.jl:56
+|>56      return a + b + c + d
+| 57  end
+| 58  
+| 59  
+| 60  
+|
+|About to run: (+)(1, 2, 5, 10)
+|1|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAA
+|AAAAA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCCA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAA
+|AAAAA
+|AAAAA
+|AAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCC


### PR DESCRIPTION
Quite ugly but seems to work:

```
julia> @enter g(1,2,3)
In g(x, y, z) at REPL[16]
>1  g(x,y,z) = f(x; y=y, z=z)

About to run: (f)(1; y=2, z=3)
```

Needs tests

Fixes #107 