### PR TITLE
protect against files being out of sync with lineinfo in the method

### DIFF
--- a/src/LineNumbers.jl
+++ b/src/LineNumbers.jl
@@ -11,7 +11,7 @@ end
 function SourceFile(data::AbstractString)
     offsets = UInt64[0]
     buf = IOBuffer(data)
-    local line
+    line = ""
     while !eof(buf)
         line = readuntil(buf,'\n')
         !eof(buf) && push!(offsets, position(buf))

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -96,7 +96,7 @@ function breakpoint_linenumbers(frame::Frame; lowered=false)
         isassigned(framecode.breakpoints, stmtidx) || continue
         bp = framecode.breakpoints[stmtidx]
         line = lowered ? stmtidx : JuliaInterpreter.linenumber(frame, stmtidx)
-        breakpoint_lines[line] = bp 
+        breakpoint_lines[line] = bp
     end
     return breakpoint_lines
 end
@@ -114,7 +114,11 @@ function print_status(io::IO, frame::Frame; force_lowered=false)
                 read(loc.filepath, String)
             end
         breakpoint_lines = breakpoint_linenumbers(frame)
-        print_sourcecode(outbuf, data, loc.line, loc.defline, loc.endline, breakpoint_lines)
+        ok = print_sourcecode(outbuf, data, loc.line, loc.defline, loc.endline, breakpoint_lines)
+        if !ok
+            printstyled(io, "failed to lookup source code in $(repr(loc.filepath)), showing lowered code:\n"; color=Base.warn_color())
+            print_codeinfo(outbuf, frame)
+        end
     else
         print_codeinfo(outbuf, frame)
     end
@@ -215,6 +219,9 @@ function print_sourcecode(io::IO, code::String, line::Integer, defline::Integer,
     code = highlight_code(code; context=io)
     file = SourceFile(code)
     stopline = min(endline, line + NUM_SOURCE_LINES_UP_DOWN[])
+    if !checkbounds(Bool, file.offsets, line)
+        return false
+    end
     startoffset, stopoffset = compute_source_offsets(code, file.offsets[line], defline, stopline; file=file)
 
     if startoffset == -1
@@ -227,6 +234,7 @@ function print_sourcecode(io::IO, code::String, line::Integer, defline::Integer,
 
     code = split(code[(startoffset+1):(stopoffset+1)],'\n')
     print_lines(io, code, line, breakpoint_lines, startline)
+    return true
 end
 
 function print_lines(io, code, current_line, breakpoint_lines, startline)


### PR DESCRIPTION
Seems to happen in Juno for some reason (https://discourse.julialang.org/t/new-debugger/21974/14). Will try figure out the root cause.