### PR TITLE
fix printing for evaluation level and make fr show the current level by default instead of level 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Basic Commands:
 - `c`: continue execution until a breakpoint is hit
 - `bt`: show a simple backtrace
 - ``` `stuff ```: run `stuff` in the current function's context
-- `fr [v::Int]`: show all variables in the current function, `v` defaults to `1`
+- `fr [v::Int]`: show all variables in the current or `v`th frame
 - `f [n::Int]`: go to the `n`-th function in the call stack
 - `w`
     - `w add expr`: add an expression to the watch list

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -75,7 +75,11 @@ execute_command(state::DebuggerState, ::Val{:st}, cmd) = true
 function execute_command(state::DebuggerState, ::Union{Val{:f}, Val{:fr}}, cmd)
     subcmds = split(cmd, ' ')
     if length(subcmds) == 1
-        new_level = 1
+        if cmd == "f"
+            new_level = 1
+        else
+            new_level = state.level
+        end
     else
         new_level = tryparse(Int, subcmds[2])
         if new_level == nothing
@@ -150,7 +154,7 @@ function execute_command(state::DebuggerState, ::Val{:?}, cmd::AbstractString)
     - `c`: continue execution until a breakpoint is hit\\
     - `bt`: show a simple backtrace\\
     - ``` `stuff ```: run `stuff` in the current function's context\\
-    - `fr [v::Int]`: show all variables in the current frame, `v` defaults to `1`\\
+    - `fr [v::Int]`: show all variables in the current or `v`th frame\\
     - `f [n::Int]`: go to the `n`-th frame\\
     - `w`\\
         - `w add expr`: add an expression to the watch list\\

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -123,7 +123,7 @@ function julia_prompt(state::DebuggerState)
     # Return early if this has already been called on the state
     isassigned(state.julia_prompt) && return state.julia_prompt[]
 
-    julia_prompt = LineEdit.Prompt(promptname(state.level, "julia");
+    julia_prompt = LineEdit.Prompt(() -> promptname(state.level, "julia");
         # Copy colors from the prompt object
         prompt_prefix = state.repl.prompt_color,
         prompt_suffix = (state.repl.envcolors ? Base.input_color : state.repl.input_color),


### PR DESCRIPTION
Fixes half of #140. @Keno, I'm having troubles reproducing the problem with the evaluation in the wrong level. For example:


```jl
julia> function f(x)
          x = 1
          g(x)
       end
f (generic function with 1 method)

julia> function g(z)
           y = 4
           return z
       end
g (generic function with 1 method)

julia> @enter f(3)
In f(x) at REPL[24]:2
 2     x = 1
>3     g(x)
 4  end

About to run: (g)(1)
1|debug> s
In g(z) at REPL[25]:2
>2      y = 4
 3      return z
 4  end

About to run: 4
1|debug> f 2 # at frame 2
In f(x) at REPL[24]:2
 2     x = 1
>3     g(x)
 4  end

About to run: (g)(1)
2|julia> x 
1

2|debug> f 1
In g(z) at REPL[25]:2
>2      y = 4
 3      return z
 4  end

About to run: 4
1|julia> x
ERROR: UndefVarError: x not defined
```