### PR TITLE
prevent erroring out of debugger if we add an argument to one of the JuliaInterpreter commands

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -23,6 +23,8 @@ function show_breakpoint(io::IO, bp::BreakpointRef)
 end
 
 function execute_command(state::DebuggerState, ::Union{Val{:c},Val{:nc},Val{:n},Val{:se},Val{:s},Val{:si},Val{:sg},Val{:so}}, cmd::AbstractString)
+    # These commands take no arguments
+    length(split(cmd)) == 1 || return execute_command(state, Val(:_), cmd) # print error
     assert_allow_step(state) || return false
     cmd == "so" && (cmd = "finish")
     ret = debug_command(state.mode, state.frame, Symbol(cmd))


### PR DESCRIPTION
Previously:

```
julia> @enter sin(2.)
In sin(x) at special/trig.jl:30
>30  absx = abs(x)
 31  if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
 32      if absx < sqrt(eps(T))
 33          return x
 34      end

About to run: (abs)(2.0)
1|debug> so lghfd
ERROR: ArgumentError: command so lghfd not recognized

julia> 
```