### PR TITLE
WIP: show a nice stacktrace when breaking on error

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -43,11 +43,11 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "0dd94cdd08c7250db6e023648cbec89674d422ca"
+git-tree-sha1 = "a1215f2d8fba52700b01fbe603e7e6b08eb7f305"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.3.0"
+version = "0.3.2"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -11,13 +11,14 @@ function assert_allow_step(state)
     return true
 end
 
-function show_breakpoint(io::IO, bp::BreakpointRef)
+function show_breakpoint(io::IO, bp::BreakpointRef, state::DebuggerState)
     outbuf = IOContext(IOBuffer(), io)
     if bp.err === nothing
         print(outbuf, "Hit breakpoint:\n")
     else
         print(outbuf, "Breaking for error:\n")
-        Base.display_error(outbuf, bp.err, [])
+        Base.display_error(outbuf, bp.err, state.frame)
+        println(outbuf)
     end
     print(io, String(take!(outbuf.io)))
 end
@@ -37,7 +38,7 @@ function execute_command(state::DebuggerState, ::Union{Val{:c},Val{:nc},Val{:n},
         if pc isa BreakpointRef
             if pc.stmtidx != 0 # This is the dummy breakpoint to stop just after entering a call
                 if state.terminal !== nothing # fix this, it happens when a test hits this and hasnt set a terminal
-                    show_breakpoint(Base.pipe_writer(state.terminal), pc)
+                    show_breakpoint(Base.pipe_writer(state.terminal), pc, state)
                 end
             end
             if pc.err !== nothing

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -65,7 +65,6 @@ function f_end(x)
 end
 "we don't want to see this in the source code printing"
 
-
 @testset "UI" begin
     if Sys.isunix() && VERSION >= v"1.1.0"
         Debugger._print_full_path[] = false
@@ -73,7 +72,7 @@ end
 
         function run_terminal_test(frame, commands, validation)
             TerminalRegressionTests.automated_test(joinpath(@__DIR__, validation), commands) do emuterm
-            #TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm                
+            #TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm
                 repl = REPL.LineEditREPL(emuterm, true)
                 repl.interface = REPL.setup_interface(repl)
                 repl.specialdisplay = REPL.REPLDisplay(repl)
@@ -99,6 +98,12 @@ end
         run_terminal_test(@make_frame(f_end(2)),
                           ["n\n", "n\n", "n\n"],
                           "ui/history_floor.multiout")
+
+        Debugger.break_on(:error)
+        run_terminal_test(@make_frame(error("foo")),
+                          ["c\n", "bt\n", "q\n"],
+                          "ui/history_break_error.multiout")
+        Debugger.break_off(:error)
 
         if v"1.1">= VERSION < v"1.2"
             run_terminal_test(@make_frame(my_gcd_noinfo(10, 20)),

--- a/test/ui/history_break_error.multiout
+++ b/test/ui/history_break_error.multiout
@@ -1,0 +1,82 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|In error(s) at error.jl:33
+|>33  error(s::AbstractString) = throw(ErrorException(s))
+|
+|About to run: (ErrorException)("foo")
+|1|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCC
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|In error(s) at error.jl:33
+|>33  error(s::AbstractString) = throw(ErrorException(s))
+|
+|About to run: (ErrorException)("foo")
+|1|debug> c
+|Breaking for error:
+|ERROR: foo
+|Stacktrace:
+| [1] error(::String) at error.jl:33
+|
+|In error(s) at error.jl:33
+|>33  error(s::AbstractString) = throw(ErrorException(s))
+|
+|About to run: (throw)(ErrorException("foo"))
+|1|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCCA
+|AAAAAAAAAAAAAAAAAAA
+|DDDDDDDDDD
+|EEEEEEEEEEE
+|EEEEEEEEEEEAAAAAAAAEAAAAEEEEEEEEEEE
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCC
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|In error(s) at error.jl:33
+|>33  error(s::AbstractString) = throw(ErrorException(s))
+|
+|About to run: (ErrorException)("foo")
+|1|debug> c
+|Breaking for error:
+|ERROR: foo
+|Stacktrace:
+| [1] error(::String) at error.jl:33
+|
+|In error(s) at error.jl:33
+|>33  error(s::AbstractString) = throw(ErrorException(s))
+|
+|About to run: (throw)(ErrorException("foo"))
+|1|debug> bt
+|[1] error(s) at error.jl:33
+|  | s::String = "foo"
+|1|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCCA
+|AAAAAAAAAAAAAAAAAAA
+|DDDDDDDDDD
+|EEEEEEEEEEE
+|EEEEEEEEEEEAAAAAAAAEAAAAEEEEEEEEEEE
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAA
+|BBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCCAA
+|AAAAAAAAAAAAAAAAAAAAAAAAAAA
+|AAAAAAAAAAAAAAAAAAAAA
+|CCCCCCCCC


### PR DESCRIPTION
Need to figure out how to deal with the absolute paths in the stacktrace when breaking on error. There isn't really a nice way to change this.

Fixes #145 