### PR TITLE
add an error message if trying to enter a compiled function

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -86,6 +86,7 @@ function _make_frame(mod, arg)
     quote
         theargs = $(esc(args))
         frame = JuliaInterpreter.enter_call_expr(Expr(:call,theargs...))
+        frame === nothing && error("failed to enter the function, perhaps it is set to run in compiled mode")
         frame = JuliaInterpreter.maybe_step_through_kwprep!(frame)
         frame = JuliaInterpreter.maybe_step_through_wrapper!(frame)
         JuliaInterpreter.maybe_next_call!(frame)


### PR DESCRIPTION
Not the best error message but it is better than status quo

Closes https://github.com/JuliaDebug/Debugger.jl/issues/150