### PR TITLE
prepare for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Debugger"
 uuid = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -12,10 +12,10 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-CodeTracking = "0.3.2, 0.4"
-Crayons = "3"
+CodeTracking = "0.3.2, 0.4, 0.5"
+Crayons = "3, 4"
 Highlights = "0.3.1"
-JuliaInterpreter = "0.3"
+JuliaInterpreter = "0.3.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Debugger"
 uuid = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -15,7 +15,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 CodeTracking = "0.3.2, 0.4, 0.5"
 Crayons = "3, 4"
 Highlights = "0.3.1"
-JuliaInterpreter = "0.3.3"
+JuliaInterpreter = "0.4"
 julia = "1"
 
 [extras]

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 1.0
 Highlights 0.3.1
 Crayons 3.0.0
 CodeTracking 0.3.2
-JuliaInterpreter 0.3.3
+JuliaInterpreter 0.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 1.0
 Highlights 0.3.1
 Crayons 3.0.0
 CodeTracking 0.3.2
-JuliaInterpreter 0.3
+JuliaInterpreter 0.3.3


### PR DESCRIPTION
- reexport some more breakpoint functionality (#133) 
- fix printing for the current evaluation level (#142)
- make fr show the current level by default instead of level 1 (#142)
- prevent erroring out of debugger on bad input commands  (#143)
- use Base.error_color() in error messages to be consistent with Base for errors (#144) 
- show an error message on empty first command (#149) 
- add an error message if trying to `@enter` a compiled function (#151) 
- show a stacktrace when breaking on error (#147) 
- add error message when using the macros on invalid expressions 

