### PR TITLE
fix for bad line info for certain statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 script:
   - julia --project --color=yes -e 'using Pkg;
                         Pkg.instantiate();
-                        Pkg.add([PackageSpec(url = "https://github.com/KristofferC/TerminalRegressionTests.jl", rev = "kc/compat"),
+                        Pkg.add([PackageSpec(name = "TerminalRegressionTests", rev = "master"),
                                  PackageSpec(name = "VT100", rev = "master")]);
                         Pkg.build();
                         Pkg.test(coverage=true)'

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,17 +5,17 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
-git-tree-sha1 = "9e697f312e39a94fc9e0368672662d34b0054a43"
+git-tree-sha1 = "7e19dccd5667e0a8d9327ac76966977dbc0df85f"
 repo-rev = "master"
 repo-url = "https://github.com/timholy/CodeTracking.jl.git"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.4.0"
+version = "0.5.0"
 
 [[Crayons]]
 deps = ["Test"]
-git-tree-sha1 = "416737eea5c50ee5a08c588ea73d77d5eebc94e7"
+git-tree-sha1 = "f621b8ef51fd2004c7cf157ea47f027fdeac5523"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "3.0.0"
+version = "4.0.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -42,12 +42,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
-deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "6a53908e8d4038bf846c4cd8ded57a6ae4f840e5"
-repo-rev = "master"
-repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
+deps = ["CodeTracking", "Dates", "Distributed", "InteractiveUtils", "Mmap", "Random", "SHA", "Test", "UUIDs"]
+git-tree-sha1 = "9234d36f3837f0071e209ed338a01e48b1423940"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.4.0"
+version = "0.4.1"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -58,6 +56,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]

--- a/src/locationinfo.jl
+++ b/src/locationinfo.jl
@@ -39,8 +39,12 @@ end
 function locinfo(frame::Frame)
     if frame.framecode.scope isa Method
         meth = frame.framecode.scope
-        def_file, def_line = JuliaInterpreter.whereis(meth)
-        current_file, current_line = JuliaInterpreter.whereis(frame)
+        ret = JuliaInterpreter.whereis(meth)
+        ret === nothing && return nothing
+        def_file, def_line = ret
+        ret = JuliaInterpreter.whereis(frame)
+        ret === nothing && return nothing
+        current_file, current_line = ret
         n_stmts = length(frame.framedata.ssavalues)
         total_lines = JuliaInterpreter.linenumber(frame, 1n_stmts) - def_line + 1
         # We currently cannot see a difference between f(x) = x and


### PR DESCRIPTION
This is what you get now @staticfloat 

```jl
julia> @enter back(1f0)
In #71(Δ) at C:\Users\Kristoffer\.julia\packages\Zygote\mlF4T\src\compiler\interface.jl:38
>38  y, Δ -> tailmemaybe(back(Δ))

About to run: (getfield)(<suppressed 119 bytes of output>, :back)
1|debug> si
In #71(Δ) at C:\Users\Kristoffer\.julia\packages\Zygote\mlF4T\src\compiler\interface.jl:38
>38  y, Δ -> tailmemaybe(back(Δ))

About to run: (∂(getfield(Main, Symbol("##5#6"))()))(1.0f0)
1|debug> 
In Pullback(Δ) at C:\Users\Kristoffer\.julia\packages\Zygote\mlF4T\src\compiler\interface2.jl:16
>1  1 ─      $(Expr(:meta, :inline))
 2  │   %2 = (getfield)(#self#, :t)
 3  │   %3 = (getindex)(%2, 1)
 4  │   %4 = (%3)(Δ)
 5  │   %5 = (Zygote.gradindex)(%4, 2)

About to run: $(Expr(:meta, :inline))
1|debug> 
In Pullback(Δ) at C:\Users\Kristoffer\.julia\packages\Zygote\mlF4T\src\compiler\interface2.jl:16
 1  1 ─      $(Expr(:meta, :inline))
>2  │   %2 = (getfield)(#self#, :t)
 3  │   %3 = (getindex)(%2, 1)
 4  │   %4 = (%3)(Δ)
 5  │   %5 = (Zygote.gradindex)(%4, 2)
 6  │   %6 = (tuple)(nothing, %5)

About to run: (getfield)(∂(getfield(Main, Symbol("##5#6"))()), :t)
1|debug> 
In Pullback(Δ) at C:\Users\Kristoffer\.julia\packages\Zygote\mlF4T\src\compiler\interface2.jl:16
>1  ignore(T) = all(T -> T <: Type, T.parameters)
 2  
 3  @generated function _forward(ctx::Context, f, args...)
 4    T = Tuple{f,args...}
 5    ignore(T) && return :(f(args...), Pullback{$T}(()))

About to run: (getindex)(<suppressed 4280 bytes of output>, 1)
1|debug> 
```