### PR TITLE
release 0.4.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
 deps = ["InteractiveUtils", "Test", "UUIDs"]
-git-tree-sha1 = "fd9c4a8cf1c51516145b686981ee689524bcb458"
+git-tree-sha1 = "9b21a2dfe51ba71fdc5688039075819196595367"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.5.4"
+version = "0.5.7"
 
 [[Crayons]]
 deps = ["Test"]
@@ -41,11 +41,11 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "0ccffe649b5288df99f2ff9eca88672a0ca5d9c8"
+git-tree-sha1 = "3446fc94431daec86574672a748696485d3c0487"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.4.1"
+version = "0.5.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Debugger"
 uuid = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -12,10 +12,10 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-CodeTracking = "0.3.2, 0.4, 0.5"
+CodeTracking = "0.5.7"
 Crayons = "3, 4"
 Highlights = "0.3.1"
-JuliaInterpreter = "0.4"
+JuliaInterpreter = "0.5"
 julia = "1"
 
 [extras]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 1.0
 Highlights 0.3.1
 Crayons 3.0.0
-CodeTracking 0.3.2
-JuliaInterpreter 0.4
+CodeTracking 0.5.7
+JuliaInterpreter 0.5

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -66,14 +66,16 @@ function execute_command(state::DebuggerState, v::Union{Val{:c},Val{:nc},Val{:n}
 end
 
 function execute_command(state::DebuggerState, ::Val{:bt}, cmd)
+    io = Base.pipe_writer(state.terminal)
+    iob = IOContext(IOBuffer(), io)
     num = 0
     frame = state.frame
     while frame !== nothing
         num += 1
-        print_frame(Base.pipe_writer(state.terminal), num, frame; current_line=true)
+        print_frame(iob, num, frame; current_line=true)
         frame = caller(frame)
     end
-    println()
+    print(io, String(take!(iob.io)))
     return false
 end
 


### PR DESCRIPTION
Needs a new tag of JuliaInterpreter

- fix for bad line info for certain statements  (#158)
- use CodeTracking for source lookup (#160) 
- make robust against failures in code highlighting (#164) 
- fix printing for calling Core._apply (#166) 
-  implement `until` (#169) 
- add a shortcut to change the number of source code shown (#171) 


