### PR TITLE
Release 0.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Debugger"
 uuid = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -15,7 +15,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 CodeTracking = "0.5.7"
 Crayons = "3, 4"
 Highlights = "0.3.1"
-JuliaInterpreter = "0.5"
+JuliaInterpreter = "0.6"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
- Add a breakpoint UI (#181)
- Bugfix with lowered code printing on on JuliaInterpreter 0.5.1 (#182)
- Add `up`/`down` commands to navigate the call stack (#178)

Needs a new tag for JuliaInterpreter.