### PR TITLE
Remove additional backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Breakpoints:
 - `bp`
     - `bp add`
         - `bp add "file.jl":line`: add a breakpoint att file `file.jl` on `line`
-        - `bp add func`[:line]`: add a breakpoint to function `func` at `line` (defaulting to first line)
+        - `bp add func [:line]`: add a breakpoint to function `func` at `line` (defaulting to first line)
         - `bp add func(::Float64, Int)[:line]`: add a breakpoint to methods matching the signature at `line` (defaulting to first line)
         - `bp add func(x, y)[:line]`: add a breakpoint to the method matching the types of the local variable `x`, `y` etc.
         - `bp add line` add a breakpoint to `line` of the file of the current function

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -280,7 +280,7 @@ function execute_command(state::DebuggerState, ::Union{Val{:help}, Val{:?}}, cmd
             Breakpoints:\\
             - `bp add`\\
                 - `bp add "file.jl":line`: add a breakpoint att file `file.jl` on line `line`\\
-                - `bp add func`[:line]`: add a breakpoint to function `func` at line `line` (defaulting to first line)\\
+                - `bp add func [:line]`: add a breakpoint to function `func` at line `line` (defaulting to first line)\\
                 - `bp add func(::Float64, Int)[:line]`: add a breakpoint to methods matching the signature at line `line` (defaulting to first line)\\
                 - `bp add func(x, y)[:line]`: add a breakpoint to the method matching the types of the local variable `x`, `y` etc.\\
                 - `bp add line` add a breakpoint to `line` of the file of the current function\\


### PR DESCRIPTION
Additional backtick causing incorrect colors in terminal when in help mode.