### PR TITLE
use MonokaiMini theme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [compat]
 CodeTracking = "0.5.7"
 Crayons = "3, 4"
-Highlights = "0.4"
+Highlights = "0.4.3"
 JuliaInterpreter = "0.7"
 julia = "1"
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -191,7 +191,7 @@ end
 end
 
 const _syntax_highlighting = Ref(Sys.iswindows() ? HIGHLIGHT_SYSTEM_COLORS : HIGHLIGHT_256_COLORS)
-const _current_theme = Ref{Type{<:Highlights.AbstractTheme}}(Highlights.Themes.MonokaiTheme)
+const _current_theme = Ref{Type{<:Highlights.AbstractTheme}}(Highlights.Themes.MonokaiMiniTheme)
 
 set_theme(theme::Type{<:Highlights.AbstractTheme}) = _current_theme[] = theme
 set_highlight(opt::HighlightOption) = _syntax_highlighting[] = opt


### PR DESCRIPTION
Supersedes https://github.com/JuliaDebug/Debugger.jl/pull/87.

[MonokaiMini](https://github.com/JuliaDocs/Highlights.jl/pull/36) is a theme that should at least be readable on most terminal backgrounds, and seems like a better default than Monokai.