### PR TITLE
Some breakpoint fixes

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -95,7 +95,7 @@ function _make_frame(mod, arg)
     end
 end
 
-_check_is_call(arg) = !(arg isa Expr && arg.head == :call) && throw(ArgumentError("@enter and @run should be applied to a function call"))
+_check_is_call(arg) = isexpr(arg, :call) || throw(ArgumentError("@enter and @run should be applied to a function call"))
 
 macro make_frame(arg)
     _make_frame(__module__, arg)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -49,7 +49,7 @@ function add_breakpoint!(state::DebuggerState, cmd::AbstractString)
     end
 
     line = nothing
-    if location_expr isa Expr && location_expr.head == :call && location_expr.args[1] == :(:)
+    if isexpr(location_expr, :call) && location_expr.args[1] == :(:)
         line = location_expr.args[3]
         line isa Integer || return bp_error("line number to the right of `:` should be given as an integer")
         location_expr = location_expr.args[2]
@@ -76,7 +76,7 @@ function add_breakpoint!(state::DebuggerState, cmd::AbstractString)
         else
             # check that the expr is a chain of getproperty calls
             expr = fsym = location_expr
-            if expr isa Expr && expr.head == :call
+            if isexpr(expr, :call)
                 has_args = true
                 expr = expr.args[1]
             end
@@ -116,7 +116,7 @@ function add_breakpoint!(state::DebuggerState, cmd::AbstractString)
 
     fsym, f_args = location_expr.args[1], location_expr.args[2:end]
     type_args = false
-    if any(arg -> arg isa Expr && arg.head == :(::), f_args)
+    if any(arg -> isexpr(arg, :(::)), f_args)
         if !all(arg -> arg.head == :(::), f_args)
             return bp_error("all arguments should have `::` if one does")
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -135,6 +135,17 @@ bp = breakpoints()[1]
 @test bp.f === cos
 @test bp.line == 5
 JuliaInterpreter.remove()
+execute_command(state, Val{:bp}(), """bp add Base.sin(x)""")
+bp = breakpoints()[1]
+@test bp.f === sin
+@test bp.sig == Tuple{Float64}
+JuliaInterpreter.remove()
+execute_command(state, Val{:bp}(), """bp add Base.sin(x):10""")
+bp = breakpoints()[1]
+@test bp.f === sin
+@test bp.sig == Tuple{Float64}
+@test bp.line == 10
+JuliaInterpreter.remove()
 execute_command(state, Val{:bp}(), """bp add 1+1""")
 bp = breakpoints()[1]
 @test bp.f === +

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -115,44 +115,59 @@ bp = breakpoints()[1]
 @test bp.f === cos
 @test bp.sig == Tuple{Float64}
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), "bp add cos(::Float32)")
 bp = breakpoints()[1]
+@test bp.f == cos
 @test bp.sig == Tuple{Float32}
 JuliaInterpreter.remove()
+
+TT = Float32
+execute_command(state, Val{:bp}(), "bp add cos(::TT)")
+bp = breakpoints()[1]
+@test bp.f == cos
+@test bp.sig == Tuple{Float32}
+JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add "foo.jl":10 x>3""")
 bp = breakpoints()[1]
 @test bp.path == "foo.jl"
 @test bp.line == 10
 @test bp.condition == :(x > 3)
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add 10""")
 bp = breakpoints()[1]
 @test bp.line == 10
 @test bp.path == CodeTracking.whereis(@which sin(1.0))[1]
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add Base.cos:5""")
 bp = breakpoints()[1]
 @test bp.f === cos
 @test bp.line == 5
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add Base.sin(x)""")
 bp = breakpoints()[1]
 @test bp.f === sin
 @test bp.sig == Tuple{Float64}
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add Base.sin(x):10""")
 bp = breakpoints()[1]
 @test bp.f === sin
 @test bp.sig == Tuple{Float64}
 @test bp.line == 10
 JuliaInterpreter.remove()
+
 execute_command(state, Val{:bp}(), """bp add 1+1""")
 bp = breakpoints()[1]
 @test bp.f === +
 @test bp.sig == Tuple{Int, Int}
+JuliaInterpreter.remove()
 
 # toggle
-JuliaInterpreter.remove()
 execute_command(state, Val{:bp}(), """bp add sin""")
 execute_command(state, Val{:bp}(), """bp add cos""")
 execute_command(state, Val{:bp}(), """bp toggle 1""")
@@ -163,9 +178,9 @@ bp2 = breakpoints()[2]
 execute_command(state, Val{:bp}(), """bp toggle""")
 @test bp.enabled[] == true
 @test bp2.enabled[] == false
+JuliaInterpreter.remove()
 
 # disable / enable
-JuliaInterpreter.remove()
 execute_command(state, Val{:bp}(), """bp add sin""")
 execute_command(state, Val{:bp}(), """bp add cos""")
 execute_command(state, Val{:bp}(), """bp disable 1""")


### PR DESCRIPTION
```
julia> @enter collect(combinations(1:3,2))
In collect(itr) at array.jl:558
>558  collect(itr) = _collect(1:1 #= Array =#, itr, IteratorEltype(itr), IteratorSize(itr))

About to run: (Colon())(1, 1)
1|debug> bp add Base.iterate(itr)
[ Info: added breakpoint for method iterate(::Combinatorics.Combinations{UnitRange{Int64}})
1] iterate(::Combinatorics.Combinations{UnitRange{Int64}})

1|debug> bp add Base.iterate(::Combinatorics.Combinations)
[ Info: added breakpoint for method iterate(::Combinatorics.Combinations)
1] iterate(::Combinatorics.Combinations{UnitRange{Int64}})
2] iterate(::Combinatorics.Combinations)

1|debug> bp add Base.iterate(::Combinatorics.Combinations{UnitRange{Int64}})
[ Info: added breakpoint for method iterate(::Combinatorics.Combinations{UnitRange{Int64}})
1] iterate(::Combinatorics.Combinations{UnitRange{Int64}})
2] iterate(::Combinatorics.Combinations)

1|julia> typeof(itr)
Combinatorics.Combinations{UnitRange{Int64}}
```

Fixes #219 