### PR TITLE
Automatically wrap code in at-enter/run macros

### DIFF
--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -95,8 +95,15 @@ function _make_frame(mod, arg)
     end
 end
 
+function _isdotcall(ex::Expr)
+    op = ex.args[1]
+    return op isa Symbol && Base.isoperator(op) && startswith(string(op), ".")
+end
+
+_iscall(ex) = isexpr(ex, :call) && !_isdotcall(ex)
+
 function _preprocess_enter(__source__, ex)
-    if isexpr(ex, :call)
+    if _iscall(ex)
         return nothing, ex
     else
         @gensym thunk

--- a/src/Debugger.jl
+++ b/src/Debugger.jl
@@ -95,24 +95,35 @@ function _make_frame(mod, arg)
     end
 end
 
-_check_is_call(arg) = isexpr(arg, :call) || throw(ArgumentError("@enter and @run should be applied to a function call"))
+function _preprocess_enter(__source__, ex)
+    if isexpr(ex, :call)
+        return nothing, ex
+    else
+        @gensym thunk
+        preamble = Expr(:(=), :($thunk()), Expr(:block, __source__, ex))
+        arg = :($thunk())
+        return esc(preamble), arg
+    end
+end
 
 macro make_frame(arg)
     _make_frame(__module__, arg)
 end
 
-macro enter(arg)
-    _check_is_call(arg)
+macro enter(ex)
+    preamble, arg = _preprocess_enter(__source__, ex)
     quote
+        $preamble
         let frame = $(_make_frame(__module__, arg))
             RunDebugger(frame)
         end
     end
 end
 
-macro run(arg)
-    _check_is_call(arg)
+macro run(ex)
+    preamble, arg = _preprocess_enter(__source__, ex)
     quote
+        $preamble
         let frame = $(_make_frame(__module__, arg))
             RunDebugger(frame; initial_continue=true)
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,5 +1,6 @@
 # Issue #14
 
+using Debugger: _iscall
 using JuliaInterpreter: JuliaInterpreter, pc_expr, evaluate_call!, finish_and_return!, @lookup, enter_call_expr, breakpoints
 runframe(frame::Frame, pc=frame.pc[]) = Some{Any}(finish_and_return!(Compiled(), frame))
 
@@ -201,3 +202,13 @@ execute_command(state, Val{:bp}(), """bp add Base""")
 execute_command(state, Val{:bp}(), """bp add lfdshfds""")
 @test length(breakpoints()) == 0
 @info "END ERRORS -------------------------------------"
+
+@testset "_iscall" begin
+    @test _iscall(:(1 + 2))
+    @test _iscall(:($(Symbol(".f"))(1, 2)))
+    @test _iscall(:(f(1, 2)))
+    @test _iscall(:($(+)(1, 2)))
+    @test !_iscall(:(1 .+ 2))
+    @test !_iscall(:(f.(1, 2)))
+    @test !_iscall(:(identity() do; end))
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -93,11 +93,6 @@ import InteractiveUtils
     @test JuliaInterpreter.Variable(LINE, :line, false) in locals
 end
 
-# These are LoadError because the error happens at macro expansion
-@test_throws LoadError @macroexpand @enter "foo"
-@test_throws LoadError @macroexpand @enter 1
-@test_throws LoadError @macroexpand @run [1,2]
-
 # Breakpoints
 frame = Debugger.@make_frame sin(1.0)
 state = dummy_state(frame)


### PR DESCRIPTION
close #222 

It works, but strangely the closing bracket is missing in this example:

```julia
julia> @enter exp.(1 .+ 2)
In ##thunk#381() at REPL[24]:1
>1  @enter exp.(1 .+ 2

About to run: (Base.Broadcast.broadcasted)(+, 1, 2)
1|debug>
```