### PR TITLE
Added ability to toggle compact mode on/off with the single letter 'M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Misc:
 - `C`: toggle compiled mode
 - `L`: toggle showing lowered code instead of source code
 - `+`/`-`: increase / decrease the number of lines of source code shown
+- `M`: toggle compact mode display. Compact mode removes common leading white space
 
 Stepping (basic):
 - `n`: step to the next line

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -244,6 +244,7 @@ function execute_command(state::DebuggerState, ::Union{Val{:help}, Val{:?}}, cmd
             - `C`: toggle compiled mode\\
             - `L`: toggle showing lowered code instead of source code\\
             - `+`/`-`: increase / decrease the number of lines of source code shown\\
+            - `M`: toggle compact mode display. Compact mode removes common leading white space\\
 
 
             Stepping (basic):\\

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -142,6 +142,7 @@ function print_status(io::IO, frame::Frame; force_lowered=false)
 end
 
 const NUM_SOURCE_LINES_UP_DOWN = Ref(4)
+const COMPACT_MODE = Ref(true)
 
 function print_codeinfo(io::IO, frame::Frame)
     src = frame.framecode.src
@@ -258,20 +259,22 @@ function print_lines(io, code, current_line, breakpoint_lines, startline)
     end
     stopline = startline + length(code) - 1
 
-    # Count indentation level (only count spaces for now)
-    min_indentation = typemax(Int)
-    for textline in code
-        all(isspace, textline) && continue
-        isempty(textline) && continue
-        indent_line = 0
-        for char in textline
-            char != ' ' && break
-            indent_line += 1
+    if COMPACT_MODE[]
+        # Count indentation level (only count spaces for now)
+        min_indentation = typemax(Int)
+        for textline in code
+            all(isspace, textline) && continue
+            isempty(textline) && continue
+            indent_line = 0
+            for char in textline
+                char != ' ' && break
+                indent_line += 1
+            end
+            min_indentation = min(min_indentation, indent_line)
         end
-        min_indentation = min(min_indentation, indent_line)
-    end
-    for i in 1:length(code)
-        code[i] = code[i][min_indentation+1:end]
+        for i in 1:length(code)
+            code[i] = code[i][min_indentation+1:end]
+        end
     end
     lineno = startline
     stoplinelength = ndigits(stopline)

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -133,7 +133,18 @@ function RunDebugger(frame, repl = nothing, terminal = nothing; initial_continue
             else
                 LineEdit.edit_insert(s, "-")
             end
+        end,
+        'M' => function (s, args...)
+            if isempty(s) || position(LineEdit.buffer(s)) == 0
+                COMPACT_MODE[] = !COMPACT_MODE[]
+                println(Base.pipe_writer(terminal))
+                print_status(Base.pipe_writer(terminal), active_frame(state); force_lowered=state.lowered_status)
+                LineEdit.write_prompt(state.terminal, panel)
+            else
+                LineEdit.edit_insert(s, "-")
+            end
         end
+        
     )
 
     state.standard_keymap = Dict{Any,Any}[skeymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]


### PR DESCRIPTION
…' debugger command.  Compact mode removes common leading white space from the line listing