### PR TITLE
Make install code run if users copy and paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Installation
 
 ```jl
-]add Debugger
+julia> import Pkg; Pkg.add("Debugger")
 ```
 
 # Usage


### PR DESCRIPTION
New Julia users may not understand the meaning of ] to enter the
package manager from the Julia REPL. Instead, start with code that
works when they copy and paste.

A debugger was one of the first things I looked for as a new Julia user. I copy pasted `] add Debugger` and got a syntax error. This change avoids that error, slightly lowering the bar to new users.