### PR TITLE
fix `defline` when method start is unknown

### DIFF
--- a/src/locationinfo.jl
+++ b/src/locationinfo.jl
@@ -21,7 +21,7 @@ function locinfo(frame::Frame)
         if unknown_start
             isfile(current_file) || return nothing
             body = read(current_file, String)
-            defline = 0 # We are not sure where the context start in cases like these, could be improved?
+            defline = 1 # We are not sure where the context start in cases like these, could be improved?
         end
         return defline, deffile, current_line, body
     else


### PR DESCRIPTION
https://github.com/JuliaDebug/Debugger.jl/commit/183c5b4eaebf2ef20d84457b1862fecbe6fb3a1e#r67187294