### PR TITLE
fix typos

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -52,7 +52,7 @@ function execute_command(state::DebuggerState, v::Union{Val{:c},Val{:nc},Val{:n}
         state.frame, pc = ret
         if pc isa BreakpointRef
             if pc.stmtidx != 0 # This is the dummy breakpoint to stop just after entering a call
-                if state.terminal !== nothing # fix this, it happens when a test hits this and hasnt set a terminal
+                if state.terminal !== nothing # fix this, it happens when a test hits this and hasn't set a terminal
                     show_breakpoint(Base.pipe_writer(state.terminal), pc, state)
                 end
             end

--- a/test/ui.jl
+++ b/test/ui.jl
@@ -1,6 +1,6 @@
 #
 #
-# From base, but copied here to make sure we don't fail bacause base changed
+# From base, but copied here to make sure we don't fail because base changed
 function my_gcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}
     a == 0 && return abs(b)
     b == 0 && return abs(a)


### PR DESCRIPTION
```
sed -i "s/bacause/because/g" Debugger.jl/test/ui.jl
sed -i "s/hasnt/hasn't/g" Debugger.jl/src/commands.jl
```