### PR TITLE
update `LineEdit.complete_line` with stdlib repl completion changes

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -229,7 +229,7 @@ mutable struct DebugCompletionProvider <: REPL.CompletionProvider
     state::DebuggerState
 end
 
-function LineEdit.complete_line(c::DebugCompletionProvider, s)
+function LineEdit.complete_line(c::DebugCompletionProvider, s; hint=true)
     partial = REPL.beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
 


### PR DESCRIPTION
Fixes #347

Context: https://github.com/JuliaLang/julia/pull/54311#issuecomment-2086278926

Packages are now required to add `hint` kwarg. We are defaulting `hint` to `true`.


