### PR TITLE
Show the value instead of $(QuoteNode(f)) in next-expression display

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -133,6 +133,11 @@ function print_next_expr(io::IO, frame::Frame)
     if isexpr(expr, :(=))
         expr = expr.args[2]
     end
+    if expr isa QuoteNode && !isa(expr.value, Union{Symbol, Expr})
+        # A function breakpoint can stop on a bare quoted value (e.g. the
+        # callee); show the value itself rather than `$(QuoteNode(f))` (#352)
+        expr = expr.value
+    end
     if isexpr(expr, :call) || isexpr(expr, :return)
         for i in 1:length(expr.args)
             val = try

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -251,3 +251,23 @@ end
     ret, _, _ = Debugger.completions(provider, "x", "x")
     @test "x" in ret
 end
+
+# Issue #352: a function breakpoint can stop on a bare quoted value; it should
+# not be displayed as `$(QuoteNode(f))`
+@testset "no QuoteNode in next expression display" begin
+    g352() = IOBuffer()
+    function f352()
+        x = g352()
+        println(x, "hello")
+    end
+    JuliaInterpreter.breakpoint(println)
+    try
+        frame = @make_frame f352()
+        state = dummy_state(frame)
+        execute_command(state, Val{:c}(), "c")
+        out = sprint(Debugger.print_next_expr, JuliaInterpreter.leaf(state.frame))
+        @test !occursin("QuoteNode", out)
+    finally
+        JuliaInterpreter.remove()
+    end
+end


### PR DESCRIPTION
A function breakpoint can leave the frame stopped on a bare quoted value (the callee), which `print_next_expr` printed verbatim as `About to run: $(QuoteNode(print))`. Unwrap the `QuoteNode` and show the value itself (quoted `Symbol`/`Expr` values are kept as-is so they still display with `:`).

On Julia 1.12 the call-preview logic already covers the common case; this mainly improves 1.10/1.11.

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)