### PR TITLE
Support removing breakpoints by location

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Breakpoints:
         - `bp add line [cond]`: add a breakpoint to `line` of the file of the current function with condition `cond`
     - `bp` show all breakpoints
     - `bp rm [i::Int]`: remove all or the `i`-th breakpoint
+    - `bp rm "file.jl":line`: remove the breakpoint at the given file and line
+    - `bp rm func [:line]`: remove breakpoints for the function `func` (at line `line`)
     - `bp toggle [i::Int]`: toggle all or the `i`-th breakpoint
     - `bp disable [i::Int]`: disable all or the `i`-th breakpoint
     - `bp enable [i::Int]`: enable all or the `i`-th breakpoint

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -207,3 +207,57 @@ function remove_breakpoint!(state::DebuggerState, i::Int)
     JuliaInterpreter.remove(JuliaInterpreter.breakpoints()[i])
     return true
 end
+
+# Remove breakpoints by location (`"file.jl":line`, `func` or `func:line`)
+# instead of by index (#375)
+function remove_breakpoint!(state::DebuggerState, location::AbstractString)
+    bp_error(err) = (@error err; false)
+
+    location_expr, _ = parse_as_much_as_possible(location, 1)
+    location_expr === nothing && return bp_error("failed to parse breakpoint location")
+
+    line = nothing
+    if isexpr(location_expr, :call) && location_expr.args[1] == :(:)
+        line = location_expr.args[3]
+        line isa Integer || return bp_error("line number to the right of `:` should be given as an integer")
+        location_expr = location_expr.args[2]
+    end
+
+    matches = JuliaInterpreter.AbstractBreakpoint[]
+    if location_expr isa String
+        file = location_expr
+        line === nothing && return bp_error("removing breakpoints in files needs a line number")
+        for bp in JuliaInterpreter.breakpoints()
+            bp isa JuliaInterpreter.BreakpointFileLocation || continue
+            if bp.line == line && (bp.path == file || endswith(bp.abspath, file))
+                push!(matches, bp)
+            end
+        end
+    elseif location_expr isa Symbol || location_expr isa Expr
+        f = nothing
+        for m in (moduleof(active_frame(state)), Main)
+            try
+                f_eval = Base.eval(m, location_expr)
+                if f_eval isa Function || f_eval isa Type
+                    f = f_eval
+                    break
+                end
+            catch
+            end
+        end
+        f === nothing && return bp_error("expression $(location_expr) did not evaluate to a function or type")
+        for bp in JuliaInterpreter.breakpoints()
+            bp isa JuliaInterpreter.BreakpointSignature || continue
+            bp.f === f || continue
+            if line === nothing || bp.line == line
+                push!(matches, bp)
+            end
+        end
+    else
+        return bp_error("failed to parse breakpoint location")
+    end
+
+    isempty(matches) && return bp_error("no breakpoint found at $location")
+    foreach(JuliaInterpreter.remove, matches)
+    return true
+end

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -218,6 +218,10 @@ function execute_command(state::DebuggerState, v::Union{Val{:bp}}, cmd::Abstract
             ok = add_breakpoint!(state, join(cmds[3:end], ' '))
             ok && repl_show_breakpoints()
             return false
+        elseif cmds[2] == "rm" && length(cmds) >= 3 && tryparse(Int, cmds[3]) === nothing
+            ok = remove_breakpoint!(state, join(cmds[3:end], ' '))
+            ok && repl_show_breakpoints()
+            return false
         elseif length(cmds) == 2 || length(cmds) == 3
             if cmds[2] == "on" || cmds[2] == "off"
                 break_on_off = cmds[2] == "on" ? JuliaInterpreter.break_on : JuliaInterpreter.break_off
@@ -315,6 +319,8 @@ function execute_command(state::DebuggerState, ::Union{Val{:help}, Val{:?}}, cmd
                 - `bp add line [cond]`: add a breakpoint to `line` of the file of the current function with condition `cond`\\
             - `bp` show all breakpoints\\
             - `bp rm [i::Int]`: remove all or the `i`-th breakpoint\\
+            - `bp rm "file.jl":line`: remove the breakpoint at the given file and line\\
+            - `bp rm func [:line]`: remove breakpoints for the function `func` (at line `line`)\\
             - `bp toggle [i::Int]`: toggle all or the `i`-th breakpoint\\
             - `bp disable [i::Int]`: disable all or the `i`-th breakpoint\\
             - `bp enable [i::Int]`: enable all or the `i`-th breakpoint\\

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -316,3 +316,40 @@ end
     ret, _, _ = Debugger.completions(provider, "xs", "xs")
     @test "xs" in ret
 end
+
+# Issue #375: remove breakpoints by location instead of by index
+@testset "bp rm by location" begin
+    frame = Debugger.@make_frame sin(1.0)
+    state = dummy_state(frame)
+
+    execute_command(state, Val{:bp}(), "bp add cos")
+    execute_command(state, Val{:bp}(), """bp add "foo.jl":10""")
+    execute_command(state, Val{:bp}(), """bp add "foo.jl":20""")
+    @test length(breakpoints()) == 3
+
+    execute_command(state, Val{:bp}(), """bp rm "foo.jl":10""")
+    @test length(breakpoints()) == 2
+    @test all(bp -> !(bp isa JuliaInterpreter.BreakpointFileLocation && bp.line == 10), breakpoints())
+
+    execute_command(state, Val{:bp}(), "bp rm cos")
+    @test length(breakpoints()) == 1
+    @test breakpoints()[1] isa JuliaInterpreter.BreakpointFileLocation
+
+    # removing a non-existent breakpoint errors but does not throw
+    @info "BEGIN ERRORS -------------------------------------"
+    execute_command(state, Val{:bp}(), "bp rm cos")
+    @test length(breakpoints()) == 1
+    execute_command(state, Val{:bp}(), "bp rm lkjdsflk")
+    @test length(breakpoints()) == 1
+    @info "END ERRORS -------------------------------------"
+
+    execute_command(state, Val{:bp}(), """bp add Base.sin:10""")
+    execute_command(state, Val{:bp}(), """bp add Base.sin:20""")
+    execute_command(state, Val{:bp}(), "bp rm Base.sin:10")
+    @test length(breakpoints()) == 2
+    @test all(bp -> !(bp isa JuliaInterpreter.BreakpointSignature && bp.line == 10), breakpoints())
+    execute_command(state, Val{:bp}(), "bp rm Base.sin")
+    @test length(breakpoints()) == 1
+
+    JuliaInterpreter.remove()
+end


### PR DESCRIPTION
Adds location-based removal alongside the existing index-based form:

- `bp rm "file.jl":line` removes file breakpoints at that location (matching the same way breakpoints are added, including partial path matches)
- `bp rm func` removes all breakpoints for a function/type
- `bp rm func:line` removes only the one at the given line

Documented in the README and the in-REPL help, with tests.

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)