### PR TITLE
Add p [var] command to print all or selected frame variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Querying:
 - `st`: show the "status" (current function, source code and current expression to run)
 - `bt`: show a backtrace
 - `fr [i::Int]`: show all variables in the current or `i`th frame
+- `p`
+    - `p`: print all currently defined variables
+    - `p x` : print the value of the variable `x`
 
 Evaluation:
 - `w`

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Querying:
 - `bt`: show a backtrace
 - `fr [i::Int]`: show all variables in the current or `i`th frame
 - `p`
-    - `p`: print all currently defined variables
-    - `p x` : print the value of the variable `x`
+    - `p`: print all variables in the current frame (same as `fr`)
+    - `p x [y ...]`: print the value of the variable(s) `x` (and `y` ...)
 
 Evaluation:
 - `w`

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -1,3 +1,4 @@
+
 function assert_allow_step(state)
     if state.broke_on_error
         printstyled(stderr, "Cannot step after breaking on error\n"; color=Base.error_color())
@@ -142,17 +143,22 @@ end
 
 function execute_command(state::DebuggerState, ::Val{:p}, cmd::AbstractString)
     cmds = split(cmd, r" +")
-    io = Base.pipe_writer(state.terminal)
+    io = output_stream(state)
     frame = active_frame(state)
     if length(cmds) == 1
         print_locals(io, frame)
     else
         vars = JuliaInterpreter.locals(frame)
         for requested_var in cmds[2:end]
+            found = false
             for var in vars
                 if string(var.name) == requested_var
                     print_var(io, var)
+                    found = true
                 end
+            end
+            if !found
+                printstyled(io, "no variable `$requested_var` in this frame\n"; color=Base.error_color())
             end
         end
     end
@@ -289,8 +295,8 @@ function execute_command(state::DebuggerState, ::Union{Val{:help}, Val{:?}}, cmd
             - `bt`: show a backtrace\\
             - `fr [i::Int]`: show all variables in the current or `i`th frame\\
             - `p`\\
-                - `p`: print all currently defined variables\\
-                - `p x` : print the value of the variable `x`\\
+                - `p`: print all variables in the current frame (same as `fr`)\\
+                - `p x [y ...]`: print the value of the variable(s) `x` (and `y` ...)\\
 
 
             Evaluation:\\

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -251,3 +251,18 @@ end
     ret, _, _ = Debugger.completions(provider, "x", "x")
     @test "x" in ret
 end
+
+@testset "p command" begin
+    function command_output(frame, cmd)
+        buf = IOBuffer()
+        term = REPL.Terminals.TTYTerminal("dumb", stdin, buf, stderr)
+        state = Debugger.DebuggerState(; frame=frame, terminal=term)
+        execute_command(state, Val{Symbol(first(split(cmd)))}(), cmd)
+        return String(take!(buf))
+    end
+    f_p_cmd(x) = (y = x + 1; y * 2)
+    frame = @make_frame f_p_cmd(3)
+    @test occursin("x::$Int = 3", command_output(frame, "p x"))
+    @test occursin("x::$Int = 3", command_output(frame, "p"))
+    @test occursin("no variable `nope` in this frame", command_output(frame, "p nope"))
+end


### PR DESCRIPTION
Picks up #339 by @berquist (original commit preserved) and adds a polish commit on top:

- use `output_stream(state)` like the other commands so output respects the terminal's color settings
- print an error message when a requested variable does not exist in the frame instead of silently printing nothing
- add tests

`p` prints all variables in the current frame (same as `fr`), `p x [y ...]` prints only the requested ones.

Fixes #313
Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)