### PR TITLE
Improve evaluation-mode completions by fixing the two-pass merge

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -262,34 +262,47 @@ mutable struct DebugCompletionProvider <: REPL.CompletionProvider
     state::DebuggerState
 end
 
-function LineEdit.complete_line(c::DebugCompletionProvider, s; hint=true)
+function LineEdit.complete_line(c::DebugCompletionProvider, s; hint=false)
     partial = REPL.beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
 
-    ret, range, should_complete = completions(c, full, partial)
+    ret, range, should_complete = completions(c, full, partial; hint=hint)
     return ret, partial[range], should_complete
 end
 
-function completions(c::DebugCompletionProvider, full, partial)
+function completions(c::DebugCompletionProvider, full, partial; hint::Bool=false)
     frame = c.state.frame
+    pos = lastindex(partial)
 
-    # repl backend completions
-    comps1, range1, should_complete1 = REPLCompletions.completions(full, lastindex(partial), moduleof(frame))
+    # completions in the context of the frame's module
+    comps1, range1, should_complete1 = REPLCompletions.completions(full, pos, moduleof(frame), true, hint)
     ret1 = map(_completion_text, comps1)
 
-    ignore_local(v) = v.name == Symbol("#self") && (v.value isa Type || sizeof(v.value) == 0)
+    # completions where the frame's locals are visible as globals of a temporary module
+    ignore_local(v) = v.name == Symbol("#self#") && (v.value isa Type || sizeof(v.value) == 0)
     m = Module()
     for v in locals(frame)
         ignore_local(v) && continue
         Base.eval(m, :($(v.name) = $(QuoteNode(v.value))))
     end
 
-    comps2, range2, should_complete2 = Base.invokelatest(REPLCompletions.completions, full, lastindex(partial), m)
+    comps2, range2, should_complete2 = Base.invokelatest(REPLCompletions.completions, full, pos, m, true, hint)
     ret2 = map(_completion_text, comps2)
 
-    ret = sort!(unique!(vcat(ret1, ret2)))
-    should_complete = should_complete1 | should_complete2
-    range = min(range1, range2) # Not sure about this one
+    # The two passes can return completions of different kinds (e.g. dict key
+    # completions for a local dict vs. path completions inside the string) with
+    # different replacement ranges. Merging those would corrupt the insertion,
+    # so only merge when the ranges agree; otherwise pick one pass, preferring
+    # the one whose completion consumed more context (smaller range start).
+    if range1 == range2
+        ret = sort!(unique!(vcat(ret1, ret2)))
+        range = range1
+        should_complete = should_complete1 | should_complete2
+    elseif isempty(ret2) || (!isempty(ret1) && first(range1) < first(range2))
+        ret, range, should_complete = ret1, range1, should_complete1
+    else
+        ret, range, should_complete = ret2, range2, should_complete2
+    end
 
     # Attempt to allow values to be garbage collected
     # because I don't think Julia ever GCs modules.

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -258,6 +258,14 @@ else
     _completion_text(c) = REPLCompletions.completion_text(c)
 end
 
+# The `hint` positional argument to `REPLCompletions.completions` was added in
+# Julia 1.11 (JuliaLang/julia#51229).
+@static if VERSION >= v"1.11"
+    _completions(full, pos, mod, hint) = REPLCompletions.completions(full, pos, mod, true, hint)
+else
+    _completions(full, pos, mod, hint) = REPLCompletions.completions(full, pos, mod, true)
+end
+
 mutable struct DebugCompletionProvider <: REPL.CompletionProvider
     state::DebuggerState
 end
@@ -275,7 +283,7 @@ function completions(c::DebugCompletionProvider, full, partial; hint::Bool=false
     pos = lastindex(partial)
 
     # completions in the context of the frame's module
-    comps1, range1, should_complete1 = REPLCompletions.completions(full, pos, moduleof(frame), true, hint)
+    comps1, range1, should_complete1 = _completions(full, pos, moduleof(frame), hint)
     ret1 = map(_completion_text, comps1)
 
     # completions where the frame's locals are visible as globals of a temporary module
@@ -286,7 +294,7 @@ function completions(c::DebugCompletionProvider, full, partial; hint::Bool=false
         Base.eval(m, :($(v.name) = $(QuoteNode(v.value))))
     end
 
-    comps2, range2, should_complete2 = Base.invokelatest(REPLCompletions.completions, full, pos, m, true, hint)
+    comps2, range2, should_complete2 = Base.invokelatest(_completions, full, pos, m, hint)
     ret2 = map(_completion_text, comps2)
 
     # The two passes can return completions of different kinds (e.g. dict key

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -266,3 +266,33 @@ end
     @test occursin("x::$Int = 3", command_output(frame, "p"))
     @test occursin("no variable `nope` in this frame", command_output(frame, "p nope"))
 end
+
+# Issue #338: the two completion passes (frame module / locals) can return
+# completions of different kinds with different replacement ranges; they must
+# not be merged into one broken list
+struct S_completions
+    field_a
+    field_b
+end
+@testset "completion merging" begin
+    function f_completions_merge()
+        xs = [S_completions(1, 2)]
+        d = Dict("key1" => 1)
+        return (xs, d)
+    end
+    frame = @make_frame f_completions_merge()
+    state = dummy_state(frame)
+    execute_command(state, Val{:sr}(), "sr")
+    provider = Debugger.DebugCompletionProvider(state)
+    # dict key completion for a local dict is not polluted by path completions
+    ret, _, _ = Debugger.completions(provider, "d[\"", "d[\"")
+    @test ret == ["\"key1\"]"]
+    # field completion through getindex inference on a local
+    ret, _, _ = Debugger.completions(provider, "xs[1].", "xs[1].")
+    @test ret == ["field_a", "field_b"]
+    # identifier completions from the frame module and the locals are merged
+    ret, _, _ = Debugger.completions(provider, "si", "si")
+    @test "sin" in ret
+    ret, _, _ = Debugger.completions(provider, "xs", "xs")
+    @test "xs" in ret
+end


### PR DESCRIPTION
Investigation of #338: the provider already piggybacks on the REPL's completion machinery — it calls `REPLCompletions.completions` twice, once with the frame's module and once with a temporary module holding the frame's locals as globals. The headline Julia 1.10 power-ups do work through that trick today (e.g. `xs[1].<TAB>` completes fields via inference on a local array).

What actually made completions feel weak is the merge of the two passes: results were always concatenated with `range = min(range1, range2)`. When the passes return completions of *different kinds* with different replacement ranges — e.g. `d["<TAB>` where the locals pass returns dict key completions and the frame-module pass falls back to path completions inside the string — the list was polluted and the range wrong for half the entries, corrupting the inserted text.

Now the results are only merged when the ranges agree (the common identifier case); otherwise the pass whose completion consumed more context wins. Also passes the `hint` flag through and fixes the `#self#` name typo in `ignore_local`.

Before/after on a frame with locals `xs = [S(1, 2)]`, `d = Dict("key1" => 1)`:

| input | before | after |
|---|---|---|
| `d["` | `"key1"]`, `.git/`, `.github/`, … (mixed ranges) | `"key1"]` |
| `xs[1].` | `field_a`, `field_b` | unchanged |
| `si` | merged identifiers | unchanged |

Stacked on #404 (uses `_completion_text`); will retarget to master when that merges.

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)