### PR TITLE
Chain to original keymap handler (if one exists) when not changing modes

### DIFF
--- a/src/debugmode.jl
+++ b/src/debugmode.jl
@@ -118,6 +118,7 @@ function install_repl_mode(repl = Base.active_repl; key::Char = ')')
 
     push!(repl.interface.modes, debug_mode)
 
+    key_action = get(main_mode.keymap_dict, key, LineEdit.edit_insert)
     enter_debug_mode = function (s, args...)
         if isempty(s) || position(LineEdit.buffer(s)) == 0
             buf = copy(LineEdit.buffer(s))
@@ -125,7 +126,7 @@ function install_repl_mode(repl = Base.active_repl; key::Char = ')')
                 LineEdit.state(s, debug_mode).input_buffer = buf
             end
         else
-            LineEdit.edit_insert(s, key)
+            key_action(s, args...)
         end
     end
     main_mode.keymap_dict = LineEdit.keymap_merge(main_mode.keymap_dict,


### PR DESCRIPTION
Starting with Julia v1.13, the builtin REPL has gained the ability to do automatic bracket completions when an opening bracket is typed, which then requires skipping over the character when its matching closing character is typed.

By unconditionally printing the mode-switch key, Debugger's overriding keymap handler breaks this behavior. Coordinate better behavior by instead chain-calling an existing keymap handler if one exists.

_I don't yet know how best to test something like this, so any hints as to where to start would be appreciated if tests are required._

---

Recordings made with Debugger being automatically loaded by a Startup package loaded in `startup.jl`:

**Before**
[![asciicast](https://asciinema.org/a/Xw7J25UnpO0slmUA.svg)](https://asciinema.org/a/Xw7J25UnpO0slmUA)

**After**
[![asciicast](https://asciinema.org/a/W8QfORK1jGamt2pF.svg)](https://asciinema.org/a/W8QfORK1jGamt2pF)